### PR TITLE
Disable overnight builds on tactical

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,7 @@
 #!groovy
 
 properties(
-  [[$class: 'GithubProjectProperty', displayName: 'track your appeal frontend', projectUrlStr: 'https://github.com/hmcts/track-your-appeal-frontend/'],
-   pipelineTriggers([
-     [$class: 'hudson.triggers.TimerTrigger', spec  : 'H 1 * * *']
-   ])]
+  [[$class: 'GithubProjectProperty', displayName: 'track your appeal frontend', projectUrlStr: 'https://github.com/hmcts/track-your-appeal-frontend/']]
 )
 
 @Library('Reform')


### PR DESCRIPTION

Remove overnight builds on tactcial as it is generally not in use anymore. PRs and merge to master still trigger builds

Make sure the branch has the JIRA number in it (eg. sscs-1111-do-amazing-things)

- Add a full description of what this change does and, most importantly, why.
- Include links to documentation, blog posts or even stack overflow questions that helped you.
- If it adds dependencies mention them.
- If it changes the UI consider including before and after screenshots.

## Review checklist
- [ ] Has a test analyst reviewed this change?
- [ ] Has another developer reviewed this change?
- [ ] Has a designer review this change?
- [ ] Does it have good test coverage and have you run the tests?
- [ ] Have you run the app and verified it works?
- [ ] Does the commit log tell a clear concise story? (If it's one logical change it should be one commit)
- [ ] Does it follow our ubiquitous language?
- [ ] Does it follow our [good app guidelines](http://git.reform/sscs/readme/blob/master/good-app-guidelines.md)?
