### PR TITLE
Temporarily ignore a Hoek security issue

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -4,6 +4,7 @@
     "https://nodesecurity.io/advisories/532",
     "https://nodesecurity.io/advisories/533",
     "https://nodesecurity.io/advisories/534",
-    "https://nodesecurity.io/advisories/535"
+    "https://nodesecurity.io/advisories/535",
+    "https://nodesecurity.io/advisories/566"
   ]
 }


### PR DESCRIPTION
* There appears to be a security vulnerability with Hoek, although
we don't use it directly a number of our modules have a transitive
dependency on it. More can be found here:
https://nodesecurity.io/advisories/566

