### PR TITLE
SSCS-2740 New express paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ as [events](/app/core/events.js).
 In the early stages of an appeal an email/letter is sent to the appellant containing a link/URL respectively 
 which looks like:
 
-    http://www.sscs.reform.hmcts.net/progress/hmUr1moTZj/trackyourappeal 
+    http://www.sscs.reform.hmcts.net/trackyourappeal/hmUr1moTZj
 
 The ID `hmUr1moTZj` defined within the URL is randomly generated via the backend. When a user clicks on the URL the 
 node app performs a HTTP GET request to the Java API /appeals endpoint passing the ID, the response returns the appeal 
@@ -67,7 +67,7 @@ In order to track an appeal the appellant is required to be [subscribed](https:/
     $> yarn start
 
 ### Open a browser including the ID
-    http://localhost:3000/progress/id/trackyourappeal 
+    http://localhost:3000/trackyourappeal/id 
 
 ### Running the tests
 

--- a/app/core/events.js
+++ b/app/core/events.js
@@ -8,72 +8,72 @@ const progressBar = {
 
 const events = {
   ADJOURNED: {
-    name: "ADJOURNED",
+    name: 'ADJOURNED',
     index: progressBar.DWP_RESPOND,
     contentKey: 'status.adjourned'
   },
   APPEAL_RECEIVED: {
-    name: "APPEAL_RECEIVED",
+    name: 'APPEAL_RECEIVED',
     index: progressBar.APPEAL_RECEIVED,
     contentKey: 'status.appealReceived'
   },
   CLOSED: {
-    name: "CLOSED",
+    name: 'CLOSED',
     index: progressBar.NONE,
-    contentKey: 'status.closed',
+    contentKey: 'status.closed'
   },
   DORMANT: {
-    name: "DORMANT",
+    name: 'DORMANT',
     index: progressBar.HEARING,
-    contentKey: 'status.dormant',
+    contentKey: 'status.dormant'
   },
   DWP_RESPOND: {
-    name: "DWP_RESPOND",
+    name: 'DWP_RESPOND',
     index: progressBar.DWP_RESPOND,
     contentKey: 'status.dwpRespond'
   },
   DWP_RESPOND_OVERDUE: {
-    name: "DWP_RESPOND_OVERDUE",
+    name: 'DWP_RESPOND_OVERDUE',
     index: progressBar.APPEAL_RECEIVED,
     contentKey: 'status.dwpRespondOverdue'
   },
   EVIDENCE_RECEIVED: {
-    name: "EVIDENCE_RECEIVED",
+    name: 'EVIDENCE_RECEIVED',
     index: progressBar.NONE,
-    contentKey: 'status.evidenceReceived',
+    contentKey: 'status.evidenceReceived'
   },
   HEARING: {
-    name: "HEARING",
+    name: 'HEARING',
     index: progressBar.HEARING,
     contentKey: 'status.hearing'
   },
   HEARING_BOOKED: {
-    name: "HEARING_BOOKED",
+    name: 'HEARING_BOOKED',
     index: progressBar.HEARING_BOOKED,
     contentKey: 'status.hearingBooked'
   },
   LAPSED_REVISED: {
-    name: "LAPSED_REVISED",
+    name: 'LAPSED_REVISED',
     index: progressBar.NONE,
     contentKey: 'status.lapsedRevised'
   },
   NEW_HEARING_BOOKED: {
-    name: "NEW_HEARING_BOOKED",
+    name: 'NEW_HEARING_BOOKED',
     index: progressBar.HEARING_BOOKED,
     contentKey: 'status.newHearingBooked'
   },
   PAST_HEARING_BOOKED: {
-    name: "PAST_HEARING_BOOKED",
+    name: 'PAST_HEARING_BOOKED',
     index: progressBar.DWP_RESPOND,
     contentKey: 'status.pastHearingBooked'
   },
   POSTPONED: {
-    name: "POSTPONED",
+    name: 'POSTPONED',
     index: progressBar.DWP_RESPOND,
     contentKey: 'status.postponed'
   },
   WITHDRAWN: {
-    name: "WITHDRAWN",
+    name: 'WITHDRAWN',
     index: progressBar.NONE,
     contentKey: 'status.withdrawn',
   }

--- a/app/routes.js
+++ b/app/routes.js
@@ -8,8 +8,6 @@ const { validateEmail } = require('app/middleware/validateEmail');
 const { validateSurname } = require('app/middleware/validateSurname');
 const { surnameValidationCookieCheck } = require('app/middleware/surnameValidationCookieCheck');
 const { showProgressBar } = require('app/core/UIUtils');
-const {Logger} = require('@hmcts/nodejs-logging');
-const logger = Logger.getLogger('routes.js');
 
 const express = require('express');
 const router = express.Router();
@@ -29,24 +27,24 @@ router.get('/validate-surname/:id', (req, res) => {
 
 router.post('/validate-surname/:id', validateSurname, matchSurnameToAppeal, (req, res, next) => {});
 
-router.get('/progress/:id/abouthearing', surnameValidationCookieCheck, getAppeal, aboutHearingContent, (req, res) => {
+router.get('/abouthearing/:id', surnameValidationCookieCheck, getAppeal, aboutHearingContent, (req, res) => {
   res.render('about-hearing', {data: res.locals.appeal});
 });
 
-router.get('/progress/:id/trackyourappeal', surnameValidationCookieCheck, tyaMiddleware, (req, res) => {
+router.get('/trackyourappeal/:id', surnameValidationCookieCheck, tyaMiddleware, (req, res) => {
   res.render('track-your-appeal', {data: res.locals.appeal});
 });
 
-router.get('/progress/:id/evidence', surnameValidationCookieCheck, getAppeal, (req, res) => {
+router.get('/evidence/:id', surnameValidationCookieCheck, getAppeal, (req, res) => {
   res.render('provide-evidence', {data: res.locals.appeal});
 });
 
-router.get('/progress/:id/expenses', surnameValidationCookieCheck, getAppeal, (req, res) => {
+router.get('/expenses/:id', surnameValidationCookieCheck, getAppeal, (req, res) => {
   res.render('claim-expenses', {data: res.locals.appeal});
 });
 
 // Hearing details relating to the latest event e.g. HEARING_BOOKED
-router.get('/progress/:id/hearingdetails', surnameValidationCookieCheck, getAppeal, reformatHearingDetails, (req, res) => {
+router.get('/hearingdetails/:id', surnameValidationCookieCheck, getAppeal, reformatHearingDetails, (req, res) => {
   res.render('hearing-details', {
     data: res.locals.appeal,
     event: res.locals.appeal.latestHearingBookedEvent
@@ -54,14 +52,14 @@ router.get('/progress/:id/hearingdetails', surnameValidationCookieCheck, getAppe
 });
 
 // Hearing details relating to historical events e.g. HEARING
-router.get('/progress/:id/hearingdetails/:index', surnameValidationCookieCheck, getAppeal, reformatHearingDetails, (req, res) => {
+router.get('/hearingdetails/:id/:index', surnameValidationCookieCheck, getAppeal, reformatHearingDetails, (req, res) => {
   res.render('hearing-details', {
     appeal: res.locals.appeal,
     event: res.locals.appeal.historicalEvents[req.params.index]
   });
 });
 
-router.get('/progress/:id/contactus', surnameValidationCookieCheck, getAppeal, (req, res) => {
+router.get('/contactus/:id', surnameValidationCookieCheck, getAppeal, (req, res) => {
   res.render('contact-us', {data: res.locals.appeal});
 });
 

--- a/app/services/matchSurnameToAppeal.js
+++ b/app/services/matchSurnameToAppeal.js
@@ -10,7 +10,7 @@ const matchSurnameToAppeal = (req, res, next) => {
   return request.get(`${appealsAPI}/${id}/surname/${surname}`)
     .then(() => {
       req.session.surnameHasValidated = true;
-      res.redirect(`/progress/${id}/trackyourappeal`);
+      res.redirect(`/trackyourappeal/${id}`);
     })
     .catch(error => {
       req.session.surnameHasValidated = false;

--- a/app/views/about-hearing.html
+++ b/app/views/about-hearing.html
@@ -62,7 +62,7 @@ About Hearing
                         <li><a href="/expenses/{{data.appealNumber}}">{{ i18n.claimExpenses.link }}</a></li>
                         <li><a href="/evidence/{{data.appealNumber}}">{{ i18n.evidence.provide.title }}</a></li>
                         <li><a href="/trackyourappeal/{{data.appealNumber}}">{{ i18n.common.trackYourAppeal }}</a></li>
-                        <li><a href="/progress/{{appeal.appealNumber}}/contactus">{{ i18n.contactUs.title }}</a></li>
+                        <li><a href="/contactus/{{appeal.appealNumber}}">{{ i18n.contactUs.title }}</a></li>
                     </ul>
                 </nav>
             </aside>

--- a/app/views/about-hearing.html
+++ b/app/views/about-hearing.html
@@ -56,7 +56,7 @@ About Hearing
                     <ul class="font-xsmall">
 
                         {% if data.status=='HEARING_BOOKED' or data.status=='HEARING' %}
-                        <li><a href="/progress/{{data.appealNumber}}/hearingdetails">{{ i18n.hearingDetails.checkDetails }}</a></li>
+                        <li><a href="/hearingdetails/{{data.appealNumber}}">{{ i18n.hearingDetails.checkDetails }}</a></li>
                         {% endif %}
 
                         <li><a href="/expenses/{{data.appealNumber}}">{{ i18n.claimExpenses.link }}</a></li>

--- a/app/views/about-hearing.html
+++ b/app/views/about-hearing.html
@@ -59,7 +59,7 @@ About Hearing
                         <li><a href="/progress/{{data.appealNumber}}/hearingdetails">{{ i18n.hearingDetails.checkDetails }}</a></li>
                         {% endif %}
 
-                        <li><a href="/progress/{{data.appealNumber}}/expenses">{{ i18n.claimExpenses.link }}</a></li>
+                        <li><a href="/expenses/{{data.appealNumber}}">{{ i18n.claimExpenses.link }}</a></li>
                         <li><a href="/evidence/{{data.appealNumber}}">{{ i18n.evidence.provide.title }}</a></li>
                         <li><a href="/trackyourappeal/{{data.appealNumber}}">{{ i18n.common.trackYourAppeal }}</a></li>
                         <li><a href="/progress/{{appeal.appealNumber}}/contactus">{{ i18n.contactUs.title }}</a></li>

--- a/app/views/about-hearing.html
+++ b/app/views/about-hearing.html
@@ -60,7 +60,7 @@ About Hearing
                         {% endif %}
 
                         <li><a href="/progress/{{data.appealNumber}}/expenses">{{ i18n.claimExpenses.link }}</a></li>
-                        <li><a href="/progress/{{data.appealNumber}}/evidence">{{ i18n.evidence.provide.title }}</a></li>
+                        <li><a href="/evidence/{{data.appealNumber}}">{{ i18n.evidence.provide.title }}</a></li>
                         <li><a href="/trackyourappeal/{{data.appealNumber}}">{{ i18n.common.trackYourAppeal }}</a></li>
                         <li><a href="/progress/{{appeal.appealNumber}}/contactus">{{ i18n.contactUs.title }}</a></li>
                     </ul>

--- a/app/views/about-hearing.html
+++ b/app/views/about-hearing.html
@@ -61,7 +61,7 @@ About Hearing
 
                         <li><a href="/progress/{{data.appealNumber}}/expenses">{{ i18n.claimExpenses.link }}</a></li>
                         <li><a href="/progress/{{data.appealNumber}}/evidence">{{ i18n.evidence.provide.title }}</a></li>
-                        <li><a href="/progress/{{data.appealNumber}}/trackyourappeal">{{ i18n.common.trackYourAppeal }}</a></li>
+                        <li><a href="/trackyourappeal/{{data.appealNumber}}">{{ i18n.common.trackYourAppeal }}</a></li>
                         <li><a href="/progress/{{appeal.appealNumber}}/contactus">{{ i18n.contactUs.title }}</a></li>
                     </ul>
                 </nav>

--- a/app/views/claim-expenses.html
+++ b/app/views/claim-expenses.html
@@ -34,7 +34,7 @@ Claim Expenses
                         <li><a href="/abouthearing/{{data.appealNumber}}">{{ i18n.hearing.expectations.title }}</a></li>
                         <li><a href="/evidence/{{data.appealNumber}}">{{ i18n.evidence.provide.title }}</a></li>
                         <li><a href="/trackyourappeal/{{data.appealNumber}}">{{ i18n.common.trackYourAppeal}}</a></li>
-                        <li><a href="/progress/{{appeal.appealNumber}}/contactus">{{ i18n.contactUs.title }}</a></li>
+                        <li><a href="/contactus/{{appeal.appealNumber}}">{{ i18n.contactUs.title }}</a></li>
                     </ul>
                 </nav>
             </aside>

--- a/app/views/claim-expenses.html
+++ b/app/views/claim-expenses.html
@@ -29,7 +29,7 @@ Claim Expenses
                 <nav role="navigation" aria-labelledby="subsection-title">
                     <ul class="font-xsmall">
                         {% if data.status=='HEARING_BOOKED' or data.status=='HEARING' %}
-                        <li><a href="/progress/{{data.appealNumber}}/hearingdetails">{{ i18n.hearingDetails.checkDetails }}</a></li>
+                        <li><a href="/hearingdetails/{{data.appealNumber}}">{{ i18n.hearingDetails.checkDetails }}</a></li>
                         {% endif %}
                         <li><a href="/abouthearing/{{data.appealNumber}}">{{ i18n.hearing.expectations.title }}</a></li>
                         <li><a href="/evidence/{{data.appealNumber}}">{{ i18n.evidence.provide.title }}</a></li>

--- a/app/views/claim-expenses.html
+++ b/app/views/claim-expenses.html
@@ -33,7 +33,7 @@ Claim Expenses
                         {% endif %}
                         <li><a href="/progress/{{data.appealNumber}}/abouthearing">{{ i18n.hearing.expectations.title }}</a></li>
                         <li><a href="/progress/{{data.appealNumber}}/evidence">{{ i18n.evidence.provide.title }}</a></li>
-                        <li><a href="/progress/{{data.appealNumber}}/trackyourappeal">{{ i18n.common.trackYourAppeal}}</a></li>
+                        <li><a href="/trackyourappeal/{{data.appealNumber}}">{{ i18n.common.trackYourAppeal}}</a></li>
                         <li><a href="/progress/{{appeal.appealNumber}}/contactus">{{ i18n.contactUs.title }}</a></li>
                     </ul>
                 </nav>

--- a/app/views/claim-expenses.html
+++ b/app/views/claim-expenses.html
@@ -31,7 +31,7 @@ Claim Expenses
                         {% if data.status=='HEARING_BOOKED' or data.status=='HEARING' %}
                         <li><a href="/progress/{{data.appealNumber}}/hearingdetails">{{ i18n.hearingDetails.checkDetails }}</a></li>
                         {% endif %}
-                        <li><a href="/progress/{{data.appealNumber}}/abouthearing">{{ i18n.hearing.expectations.title }}</a></li>
+                        <li><a href="/abouthearing/{{data.appealNumber}}">{{ i18n.hearing.expectations.title }}</a></li>
                         <li><a href="/progress/{{data.appealNumber}}/evidence">{{ i18n.evidence.provide.title }}</a></li>
                         <li><a href="/trackyourappeal/{{data.appealNumber}}">{{ i18n.common.trackYourAppeal}}</a></li>
                         <li><a href="/progress/{{appeal.appealNumber}}/contactus">{{ i18n.contactUs.title }}</a></li>

--- a/app/views/claim-expenses.html
+++ b/app/views/claim-expenses.html
@@ -32,7 +32,7 @@ Claim Expenses
                         <li><a href="/progress/{{data.appealNumber}}/hearingdetails">{{ i18n.hearingDetails.checkDetails }}</a></li>
                         {% endif %}
                         <li><a href="/abouthearing/{{data.appealNumber}}">{{ i18n.hearing.expectations.title }}</a></li>
-                        <li><a href="/progress/{{data.appealNumber}}/evidence">{{ i18n.evidence.provide.title }}</a></li>
+                        <li><a href="/evidence/{{data.appealNumber}}">{{ i18n.evidence.provide.title }}</a></li>
                         <li><a href="/trackyourappeal/{{data.appealNumber}}">{{ i18n.common.trackYourAppeal}}</a></li>
                         <li><a href="/progress/{{appeal.appealNumber}}/contactus">{{ i18n.contactUs.title }}</a></li>
                     </ul>

--- a/app/views/contact-us.html
+++ b/app/views/contact-us.html
@@ -40,7 +40,7 @@ Contact us
                         <li><a href="/progress/{{data.appealNumber}}/hearingdetails">{{ i18n.hearingDetails.checkDetails }}</a></li>
                         {% endif %}
                         <li><a href="/progress/{{data.appealNumber}}/expenses">{{ i18n.claimExpenses.link }}</a></li>
-                        <li><a href="/progress/{{data.appealNumber}}/evidence">{{ i18n.evidence.provide.title }}</a></li>
+                        <li><a href="/evidence/{{data.appealNumber}}">{{ i18n.evidence.provide.title }}</a></li>
                         <li><a href="/trackyourappeal/{{data.appealNumber}}">{{ i18n.common.trackYourAppeal}}</a></li>
                     </ul>
                 </nav>

--- a/app/views/contact-us.html
+++ b/app/views/contact-us.html
@@ -41,7 +41,7 @@ Contact us
                         {% endif %}
                         <li><a href="/progress/{{data.appealNumber}}/expenses">{{ i18n.claimExpenses.link }}</a></li>
                         <li><a href="/progress/{{data.appealNumber}}/evidence">{{ i18n.evidence.provide.title }}</a></li>
-                        <li><a href="/progress/{{data.appealNumber}}/trackyourappeal">{{ i18n.common.trackYourAppeal}}</a></li>
+                        <li><a href="/trackyourappeal/{{data.appealNumber}}">{{ i18n.common.trackYourAppeal}}</a></li>
                     </ul>
                 </nav>
             </aside>

--- a/app/views/contact-us.html
+++ b/app/views/contact-us.html
@@ -39,7 +39,7 @@ Contact us
                         {% if data.status=='HEARING_BOOKED' or data.status=='HEARING' %}
                         <li><a href="/progress/{{data.appealNumber}}/hearingdetails">{{ i18n.hearingDetails.checkDetails }}</a></li>
                         {% endif %}
-                        <li><a href="/progress/{{data.appealNumber}}/expenses">{{ i18n.claimExpenses.link }}</a></li>
+                        <li><a href="/expenses/{{data.appealNumber}}">{{ i18n.claimExpenses.link }}</a></li>
                         <li><a href="/evidence/{{data.appealNumber}}">{{ i18n.evidence.provide.title }}</a></li>
                         <li><a href="/trackyourappeal/{{data.appealNumber}}">{{ i18n.common.trackYourAppeal}}</a></li>
                     </ul>

--- a/app/views/contact-us.html
+++ b/app/views/contact-us.html
@@ -37,7 +37,7 @@ Contact us
                 <nav role="navigation" aria-labelledby="subsection-title">
                     <ul class="font-xsmall">
                         {% if data.status=='HEARING_BOOKED' or data.status=='HEARING' %}
-                        <li><a href="/progress/{{data.appealNumber}}/hearingdetails">{{ i18n.hearingDetails.checkDetails }}</a></li>
+                        <li><a href="/hearingdetails/{{data.appealNumber}}">{{ i18n.hearingDetails.checkDetails }}</a></li>
                         {% endif %}
                         <li><a href="/expenses/{{data.appealNumber}}">{{ i18n.claimExpenses.link }}</a></li>
                         <li><a href="/evidence/{{data.appealNumber}}">{{ i18n.evidence.provide.title }}</a></li>

--- a/app/views/hearing-details.html
+++ b/app/views/hearing-details.html
@@ -70,7 +70,7 @@ Hearing Details
             <h4 class="heading-small">{{ i18n.common.aboutYourAppeal }}</h4>
             <ul class="links">
                 <li><a href="/progress/{{appeal.appealNumber}}/expenses">{{ i18n.claimExpenses.link }}</a></li>
-                <li><a href="/progress/{{appeal.appealNumber}}/evidence">{{ i18n.evidence.provide.title }}</a></li>
+                <li><a href="/evidence/{{appeal.appealNumber}}">{{ i18n.evidence.provide.title }}</a></li>
                 <li><a href="/trackyourappeal/{{appeal.appealNumber}}">{{ i18n.common.trackYourAppeal }}</a></li>
                 <li><a href="/progress/{{appeal.appealNumber}}/contactus">{{ i18n.contactUs.title }}</a></li>
             </ul>

--- a/app/views/hearing-details.html
+++ b/app/views/hearing-details.html
@@ -72,7 +72,7 @@ Hearing Details
                 <li><a href="/expenses/{{appeal.appealNumber}}">{{ i18n.claimExpenses.link }}</a></li>
                 <li><a href="/evidence/{{appeal.appealNumber}}">{{ i18n.evidence.provide.title }}</a></li>
                 <li><a href="/trackyourappeal/{{appeal.appealNumber}}">{{ i18n.common.trackYourAppeal }}</a></li>
-                <li><a href="/progress/{{appeal.appealNumber}}/contactus">{{ i18n.contactUs.title }}</a></li>
+                <li><a href="/contactus/{{appeal.appealNumber}}">{{ i18n.contactUs.title }}</a></li>
             </ul>
         </div>
     </div>

--- a/app/views/hearing-details.html
+++ b/app/views/hearing-details.html
@@ -71,7 +71,7 @@ Hearing Details
             <ul class="links">
                 <li><a href="/progress/{{appeal.appealNumber}}/expenses">{{ i18n.claimExpenses.link }}</a></li>
                 <li><a href="/progress/{{appeal.appealNumber}}/evidence">{{ i18n.evidence.provide.title }}</a></li>
-                <li><a href="/progress/{{appeal.appealNumber}}/trackyourappeal">{{ i18n.common.trackYourAppeal }}</a></li>
+                <li><a href="/trackyourappeal/{{appeal.appealNumber}}">{{ i18n.common.trackYourAppeal }}</a></li>
                 <li><a href="/progress/{{appeal.appealNumber}}/contactus">{{ i18n.contactUs.title }}</a></li>
             </ul>
         </div>

--- a/app/views/hearing-details.html
+++ b/app/views/hearing-details.html
@@ -62,7 +62,7 @@ Hearing Details
             {% endfor %}
 
             <p class="about-hearing">
-                <a href="/progress/{{appeal.appealNumber}}/abouthearing">{{ i18n.hearing.expectations.link }}</a>
+                <a href="/abouthearing/{{appeal.appealNumber}}">{{ i18n.hearing.expectations.link }}</a>
             </p>
 
             <div class="updates-border"></div>

--- a/app/views/hearing-details.html
+++ b/app/views/hearing-details.html
@@ -69,7 +69,7 @@ Hearing Details
 
             <h4 class="heading-small">{{ i18n.common.aboutYourAppeal }}</h4>
             <ul class="links">
-                <li><a href="/progress/{{appeal.appealNumber}}/expenses">{{ i18n.claimExpenses.link }}</a></li>
+                <li><a href="/expenses/{{appeal.appealNumber}}">{{ i18n.claimExpenses.link }}</a></li>
                 <li><a href="/evidence/{{appeal.appealNumber}}">{{ i18n.evidence.provide.title }}</a></li>
                 <li><a href="/trackyourappeal/{{appeal.appealNumber}}">{{ i18n.common.trackYourAppeal }}</a></li>
                 <li><a href="/progress/{{appeal.appealNumber}}/contactus">{{ i18n.contactUs.title }}</a></li>

--- a/app/views/notifications/emails-stop-confirmed.html
+++ b/app/views/notifications/emails-stop-confirmed.html
@@ -18,7 +18,7 @@
                 <a href='{{urls.exitFeedbackSurvey}}'>{{ i18n.notifications.email.stopConfirmation.exitFeedbackSurveyLink }}</a>
             </p>
             <p>{{ i18n.notifications.email.stopConfirmation.linkPre }}
-                <a href='/progress/{{data.appealNumber}}/trackyourappeal'>{{ i18n.notifications.email.stopConfirmation.linkPost }}</a>
+                <a href='/trackyourappeal/{{data.appealNumber}}'>{{ i18n.notifications.email.stopConfirmation.linkPost }}</a>
             </p>
         </div>
     </div>

--- a/app/views/provide-evidence.html
+++ b/app/views/provide-evidence.html
@@ -51,7 +51,7 @@ Provide Evidence
                         <li><a href="/abouthearing/{{data.appealNumber}}">{{ i18n.hearing.expectations.title }}</a></li>
                         <li><a href="/expenses/{{data.appealNumber}}">{{ i18n.claimExpenses.link }}</a></li>
                         <li><a href="/trackyourappeal/{{data.appealNumber}}">{{ i18n.common.trackYourAppeal }}</a></li>
-                        <li><a href="/progress/{{appeal.appealNumber}}/contactus">{{ i18n.contactUs.title }}</a></li>
+                        <li><a href="/contactus/{{appeal.appealNumber}}">{{ i18n.contactUs.title }}</a></li>
                     </ul>
                 </nav>
             </aside>

--- a/app/views/provide-evidence.html
+++ b/app/views/provide-evidence.html
@@ -50,7 +50,7 @@ Provide Evidence
                         {% endif %}
                         <li><a href="/progress/{{data.appealNumber}}/abouthearing">{{ i18n.hearing.expectations.title }}</a></li>
                         <li><a href="/progress/{{data.appealNumber}}/expenses">{{ i18n.claimExpenses.link }}</a></li>
-                        <li><a href="/progress/{{data.appealNumber}}/trackyourappeal">{{ i18n.common.trackYourAppeal }}</a></li>
+                        <li><a href="/trackyourappeal/{{data.appealNumber}}">{{ i18n.common.trackYourAppeal }}</a></li>
                         <li><a href="/progress/{{appeal.appealNumber}}/contactus">{{ i18n.contactUs.title }}</a></li>
                     </ul>
                 </nav>

--- a/app/views/provide-evidence.html
+++ b/app/views/provide-evidence.html
@@ -48,7 +48,7 @@ Provide Evidence
                         {% if data.status=='HEARING_BOOKED' or data.status=='HEARING' %}
                         <li><a href="/progress/{{data.appealNumber}}/hearingdetails">{{ i18n.hearingDetails.checkDetails }}</a></li>
                         {% endif %}
-                        <li><a href="/progress/{{data.appealNumber}}/abouthearing">{{ i18n.hearing.expectations.title }}</a></li>
+                        <li><a href="/abouthearing/{{data.appealNumber}}">{{ i18n.hearing.expectations.title }}</a></li>
                         <li><a href="/progress/{{data.appealNumber}}/expenses">{{ i18n.claimExpenses.link }}</a></li>
                         <li><a href="/trackyourappeal/{{data.appealNumber}}">{{ i18n.common.trackYourAppeal }}</a></li>
                         <li><a href="/progress/{{appeal.appealNumber}}/contactus">{{ i18n.contactUs.title }}</a></li>

--- a/app/views/provide-evidence.html
+++ b/app/views/provide-evidence.html
@@ -49,7 +49,7 @@ Provide Evidence
                         <li><a href="/progress/{{data.appealNumber}}/hearingdetails">{{ i18n.hearingDetails.checkDetails }}</a></li>
                         {% endif %}
                         <li><a href="/abouthearing/{{data.appealNumber}}">{{ i18n.hearing.expectations.title }}</a></li>
-                        <li><a href="/progress/{{data.appealNumber}}/expenses">{{ i18n.claimExpenses.link }}</a></li>
+                        <li><a href="/expenses/{{data.appealNumber}}">{{ i18n.claimExpenses.link }}</a></li>
                         <li><a href="/trackyourappeal/{{data.appealNumber}}">{{ i18n.common.trackYourAppeal }}</a></li>
                         <li><a href="/progress/{{appeal.appealNumber}}/contactus">{{ i18n.contactUs.title }}</a></li>
                     </ul>

--- a/app/views/provide-evidence.html
+++ b/app/views/provide-evidence.html
@@ -46,7 +46,7 @@ Provide Evidence
                 <nav role="navigation" aria-labelledby="subsection-title">
                     <ul class="font-xsmall">
                         {% if data.status=='HEARING_BOOKED' or data.status=='HEARING' %}
-                        <li><a href="/progress/{{data.appealNumber}}/hearingdetails">{{ i18n.hearingDetails.checkDetails }}</a></li>
+                        <li><a href="/hearingdetails/{{data.appealNumber}}">{{ i18n.hearingDetails.checkDetails }}</a></li>
                         {% endif %}
                         <li><a href="/abouthearing/{{data.appealNumber}}">{{ i18n.hearing.expectations.title }}</a></li>
                         <li><a href="/expenses/{{data.appealNumber}}">{{ i18n.claimExpenses.link }}</a></li>

--- a/app/views/track-your-appeal.html
+++ b/app/views/track-your-appeal.html
@@ -109,7 +109,7 @@ Track your Appeal
             {% if data.showEvidenceReminder %}
             <div class="panel panel-border-wide">
                 <p>{{ i18n.evidence.received if data.evidenceReceived else i18n.evidence.notReceived }}<br/>
-                    <a href="/progress/{{data.appealNumber}}/evidence">{{ i18n.evidence.provide.title }}</a>
+                    <a href="/evidence/{{data.appealNumber}}">{{ i18n.evidence.provide.title }}</a>
                 </p>
             </div>
             {% endif %}
@@ -120,7 +120,7 @@ Track your Appeal
             <ul class="links">
                 <li><a href="/abouthearing/{{data.appealNumber}}">{{ i18n.hearing.expectations.title }}</a></li>
                 <li><a href="/progress/{{data.appealNumber}}/expenses">{{ i18n.claimExpenses.link }}</a></li>
-                <li><a href="/progress/{{data.appealNumber}}/evidence">{{ i18n.evidence.provide.title }}</a></li>
+                <li><a href="/evidence/{{data.appealNumber}}">{{ i18n.evidence.provide.title }}</a></li>
                 <li><a href="/progress/{{data.appealNumber}}/contactus">{{ i18n.contactUs.title }}</a></li>
             </ul>
 

--- a/app/views/track-your-appeal.html
+++ b/app/views/track-your-appeal.html
@@ -119,7 +119,7 @@ Track your Appeal
             <h3 class="heading-small">{{ i18n.common.aboutYourAppeal }}</h3>
             <ul class="links">
                 <li><a href="/abouthearing/{{data.appealNumber}}">{{ i18n.hearing.expectations.title }}</a></li>
-                <li><a href="/progress/{{data.appealNumber}}/expenses">{{ i18n.claimExpenses.link }}</a></li>
+                <li><a href="/expenses/{{data.appealNumber}}">{{ i18n.claimExpenses.link }}</a></li>
                 <li><a href="/evidence/{{data.appealNumber}}">{{ i18n.evidence.provide.title }}</a></li>
                 <li><a href="/progress/{{data.appealNumber}}/contactus">{{ i18n.contactUs.title }}</a></li>
             </ul>

--- a/app/views/track-your-appeal.html
+++ b/app/views/track-your-appeal.html
@@ -74,7 +74,7 @@ Track your Appeal
                 {% endfor %}
 
                 {% if data.status == 'HEARING_BOOKED' %}
-                <a href="/progress/{{data.appealNumber}}/hearingdetails">{{ i18n.hearingDetails.checkDetails }}</a>
+                <a href="/hearingdetails/{{data.appealNumber}}">{{ i18n.hearingDetails.checkDetails }}</a>
                 {% endif %}
 
                 {% if data.historicalEvents.length %}
@@ -96,7 +96,7 @@ Track your Appeal
                         {% endfor %}
 
                         {% if historicalEvent.contentKey === 'status.hearingBooked' %}
-                        <a href="/progress/{{data.appealNumber}}/hearingdetails/{{loop.index0}}">{{ i18n.hearingDetails.checkDetails }}</a>
+                        <a href="/hearingdetails/{{data.appealNumber}}/{{loop.index0}}">{{ i18n.hearingDetails.checkDetails }}</a>
                         {% endif %}
                     </div>
                     {% endfor %}

--- a/app/views/track-your-appeal.html
+++ b/app/views/track-your-appeal.html
@@ -121,7 +121,7 @@ Track your Appeal
                 <li><a href="/abouthearing/{{data.appealNumber}}">{{ i18n.hearing.expectations.title }}</a></li>
                 <li><a href="/expenses/{{data.appealNumber}}">{{ i18n.claimExpenses.link }}</a></li>
                 <li><a href="/evidence/{{data.appealNumber}}">{{ i18n.evidence.provide.title }}</a></li>
-                <li><a href="/progress/{{data.appealNumber}}/contactus">{{ i18n.contactUs.title }}</a></li>
+                <li><a href="/contactus/{{data.appealNumber}}">{{ i18n.contactUs.title }}</a></li>
             </ul>
 
         </div>

--- a/app/views/track-your-appeal.html
+++ b/app/views/track-your-appeal.html
@@ -118,7 +118,7 @@ Track your Appeal
 
             <h3 class="heading-small">{{ i18n.common.aboutYourAppeal }}</h3>
             <ul class="links">
-                <li><a href="/progress/{{data.appealNumber}}/abouthearing">{{ i18n.hearing.expectations.title }}</a></li>
+                <li><a href="/abouthearing/{{data.appealNumber}}">{{ i18n.hearing.expectations.title }}</a></li>
                 <li><a href="/progress/{{data.appealNumber}}/expenses">{{ i18n.claimExpenses.link }}</a></li>
                 <li><a href="/progress/{{data.appealNumber}}/evidence">{{ i18n.evidence.provide.title }}</a></li>
                 <li><a href="/progress/{{data.appealNumber}}/contactus">{{ i18n.contactUs.title }}</a></li>

--- a/test/accessibility/runPa11y.js
+++ b/test/accessibility/runPa11y.js
@@ -26,7 +26,7 @@ const accessibilityPages = [
   '/progress/md008/hearingdetails',    // hearing booked
   '/progress/md007/hearingdetails/1',  // hearing
   '/progress/md007/expenses',
-  '/progress/md007/evidence',
+  '/evidence/md007',
   manageEmailNotifications,
   `${manageEmailNotifications}/change`,
   `${manageEmailNotifications}/stop`,

--- a/test/accessibility/runPa11y.js
+++ b/test/accessibility/runPa11y.js
@@ -25,7 +25,7 @@ const accessibilityPages = [
   '/trackyourappeal/md007',
   '/progress/md008/hearingdetails',    // hearing booked
   '/progress/md007/hearingdetails/1',  // hearing
-  '/progress/md007/expenses',
+  '/expenses/md007',
   '/evidence/md007',
   manageEmailNotifications,
   `${manageEmailNotifications}/change`,

--- a/test/accessibility/runPa11y.js
+++ b/test/accessibility/runPa11y.js
@@ -17,7 +17,7 @@ const pa11yRunner = pa11y({
 const manageEmailNotifications = '/manage-email-notifications/NnwxNDg3MDY1ODI4fDExN3BsSDdrVDc=';
 
 const accessibilityPages = [
-  '/progress/md002/contactus',
+  '/contactus/md002',
   '/abouthearing/md002',
   '/trackyourappeal/md002',
   '/trackyourappeal/md005',

--- a/test/accessibility/runPa11y.js
+++ b/test/accessibility/runPa11y.js
@@ -23,8 +23,8 @@ const accessibilityPages = [
   '/trackyourappeal/md005',
   '/trackyourappeal/md008',
   '/trackyourappeal/md007',
-  '/progress/md008/hearingdetails',    // hearing booked
-  '/progress/md007/hearingdetails/1',  // hearing
+  '/hearingdetails/md008',    // hearing booked
+  '/hearingdetails/md007/1',  // hearing
   '/expenses/md007',
   '/evidence/md007',
   manageEmailNotifications,

--- a/test/accessibility/runPa11y.js
+++ b/test/accessibility/runPa11y.js
@@ -17,6 +17,7 @@ const pa11yRunner = pa11y({
 const manageEmailNotifications = '/manage-email-notifications/NnwxNDg3MDY1ODI4fDExN3BsSDdrVDc=';
 
 const accessibilityPages = [
+  '/validate-surname/md002',
   '/contactus/md002',
   '/abouthearing/md002',
   '/trackyourappeal/md002',
@@ -30,28 +31,35 @@ const accessibilityPages = [
   manageEmailNotifications,
   `${manageEmailNotifications}/change`,
   `${manageEmailNotifications}/stop`,
-  `${manageEmailNotifications}/stopconfirm`,
+  `${manageEmailNotifications}/stopconfirm`
 ];
 
 accessibilityPages.forEach((page) => {
 
   describe('Running Accessibility tests for: ' + page, () => {
 
-    let pageResults;
+    let pageResults, server;
 
     before((done) => {
-        pa11yRunner.run(request(app).get(page).url, (error, results) => {
-          if (error) {
-            throw new Error('Pa11y errored whilst testing page:' + page);
-          }
-          pageResults = results;
-          done();
+        const port = app.get('port');
+        server = app.listen(port, ()=> {
+          pa11yRunner.run(request(server).get(page).url, (error, results) => {
+            if (error) {
+              throw new Error('Pa11y error whilst testing page:' + page);
+            }
+            pageResults = results;
+            done();
+          });
         });
+    });
+
+    after(() => {
+      server.close();
     });
 
     it('should pass without errors or warnings', () => {
       let errors = pageResults.filter((result) => {
-        return result.type === 'error' || result.type === 'warning'
+        return result.type === 'error' || result.type === 'warning';
       });
       expect(errors.length).to.equal(0, JSON.stringify(errors, null, 2));
     });

--- a/test/accessibility/runPa11y.js
+++ b/test/accessibility/runPa11y.js
@@ -18,7 +18,7 @@ const manageEmailNotifications = '/manage-email-notifications/NnwxNDg3MDY1ODI4fD
 
 const accessibilityPages = [
   '/progress/md002/contactus',
-  '/progress/md002/abouthearing',
+  '/abouthearing/md002',
   '/trackyourappeal/md002',
   '/trackyourappeal/md005',
   '/trackyourappeal/md008',

--- a/test/accessibility/runPa11y.js
+++ b/test/accessibility/runPa11y.js
@@ -19,10 +19,10 @@ const manageEmailNotifications = '/manage-email-notifications/NnwxNDg3MDY1ODI4fD
 const accessibilityPages = [
   '/progress/md002/contactus',
   '/progress/md002/abouthearing',
-  '/progress/md002/trackyourappeal',
-  '/progress/md005/trackyourappeal',
-  '/progress/md008/trackyourappeal',
-  '/progress/md007/trackyourappeal',
+  '/trackyourappeal/md002',
+  '/trackyourappeal/md005',
+  '/trackyourappeal/md008',
+  '/trackyourappeal/md007',
   '/progress/md008/hearingdetails',    // hearing booked
   '/progress/md007/hearingdetails/1',  // hearing
   '/progress/md007/expenses',

--- a/test/mock/mockMatchSurnameToAppealService.js
+++ b/test/mock/mockMatchSurnameToAppealService.js
@@ -11,7 +11,7 @@ const matchSurnameToAppeal = (req, res) => {
     mockedAppeal.surname.toLowerCase() === surname.toLowerCase();
 
   if (req.session.surnameHasValidated) {
-    res.redirect(`/progress/${id}/trackyourappeal`);
+    res.redirect(`/trackyourappeal/${id}`);
   } else {
     res.status(HttpStatus.BAD_REQUEST);
     res.render('validate-surname', {

--- a/test/smoke/scenarios/cookies/cookiesTest.js
+++ b/test/smoke/scenarios/cookies/cookiesTest.js
@@ -2,21 +2,21 @@ const dbProperties = require('../../props/properties').dataBaseFields;
 Feature('Track your Appeal Cookies Tests');
 
 Scenario('clear cookies and check for cookie message',  function*(I, Properties) {
-  yield * I.goToPageAfterSurnameValidation('/progress/:id/trackyourappeal', 'appealReceivedAppealCaseId');
-  I.setSurnameValidationCookieAndGoToPage(`/progress/${appealId}/trackyourappeal`);
+  yield * I.goToPageAfterSurnameValidation('/trackyourappeal/:id', 'appealReceivedAppealCaseId');
+  I.setSurnameValidationCookieAndGoToPage(`/trackyourappeal/${appealId}`);
   I.clearCookie();
   I.see("GOV.UK uses cookies to make the site simpler. Find out more about cookies");
 });
 
 Scenario('accept cookie and verify cookie', function*(I, Properties) {
-  yield * I.goToPageAfterSurnameValidation('/progress/:id/trackyourappeal', 'appealReceivedAppealCaseId');
+  yield * I.goToPageAfterSurnameValidation('/trackyourappeal/:id', 'appealReceivedAppealCaseId');
   I.click('What to expect at your hearing');
   I.seeCookie('seen_cookie_message');
 
 });
 
 Scenario('verify cookie message page', function*(I, Properties) {
-  yield * I.goToPageAfterSurnameValidation('/progress/:id/trackyourappeal', 'appealReceivedAppealCaseId');
+  yield * I.goToPageAfterSurnameValidation('/trackyourappeal/:id', 'appealReceivedAppealCaseId');
   I.click('Find out more about cookies');
   I.seeInCurrentUrl('cookiepolicy');
   I.see("Cookie Policy");
@@ -24,7 +24,7 @@ Scenario('verify cookie message page', function*(I, Properties) {
 });
 
 Scenario('verify google analytics on page', function*(I, Properties) {
-  yield * I.goToPageAfterSurnameValidation('/progress/:id/trackyourappeal', 'appealReceivedAppealCaseId');
+  yield * I.goToPageAfterSurnameValidation('/trackyourappeal/:id', 'appealReceivedAppealCaseId');
   I.seeInSource('<script src="/public/javascripts/google-analytics-universal-tracker.js"></script>');
   I.amOnPage('/public/javascripts/tya-analytics-tracker.js');
   I.seeInSource("universalId: 'UA-91309785-1'");

--- a/test/smoke/scenarios/error_pages/errorPages.js
+++ b/test/smoke/scenarios/error_pages/errorPages.js
@@ -1,8 +1,8 @@
 Feature('Track your Appeal Error Pages Tests');
 
 Scenario('verify 404 Error Page', function*(I) {
-  yield * I.goToPageAfterSurnameValidation('/progress/:id/trackyourappeal', 'appealReceivedAppealCaseId');
-  I.amOnPage('/progress/111111/trackyourappeal');
+  yield * I.goToPageAfterSurnameValidation('/trackyourappeal/:id', 'appealReceivedAppealCaseId');
+  I.amOnPage('/trackyourappeal/111111');
   I.see("Sorry, this page could not be found");
   I.see('Cookie');
   I.click('Cookie');

--- a/test/smoke/scenarios/mock-smoke.js
+++ b/test/smoke/scenarios/mock-smoke.js
@@ -1,7 +1,7 @@
 Feature('TYA Surname');
 
 Scenario('Verify the page redirects to /validate-surname', function*(I) {
-  I.amOnPage('/progress/123/trackyourappeal');
+  I.amOnPage('/trackyourappeal/123');
   I.see('Enter your last name');
   I.seeCurrentUrlEquals('/validate-surname/123');
 });

--- a/test/smoke/scenarios/track_appeal/trackAppealPages.js
+++ b/test/smoke/scenarios/track_appeal/trackAppealPages.js
@@ -52,7 +52,7 @@ Scenario('verify appellant details after Hearing Booked', function*(I, Propertie
 });
 
 Scenario('verify hearing details', function*(I) {
-  yield * I.goToPageAfterSurnameValidation('/progress/:id/hearingdetails', 'hearingBookedAppealCaseId');
+  yield * I.goToPageAfterSurnameValidation('/hearingdetails/:id', 'hearingBookedAppealCaseId');
   I.see('Mr. C Charlie');
   I.see('Appeal reference number: SC333/33/33333');
   I.see('Date');

--- a/test/smoke/scenarios/track_appeal/trackAppealPages.js
+++ b/test/smoke/scenarios/track_appeal/trackAppealPages.js
@@ -5,7 +5,7 @@ Feature('Track your Appeal Page Tests');
 
 Scenario('verify appellant details after Appeal Received', function*(I) {
   const date = yield I.calcAppealDate('appealReceivedAppealCaseId', 35);
-  yield * I.goToPageAfterSurnameValidation('/progress/:id/trackyourappeal', 'appealReceivedAppealCaseId');
+  yield * I.goToPageAfterSurnameValidation('/trackyourappeal/:id', 'appealReceivedAppealCaseId');
   I.see('Mr. A Alpha');
   I.see('Appeal reference number: SC111/11/1111');
   I.see(pageText.progressBar.screenReader.appeal.happened);
@@ -17,7 +17,7 @@ Scenario('verify appellant details after Appeal Received', function*(I) {
 });
 
 Scenario('verify appellant details after DWP response received', function*(I, Properties) {
-  yield * I.goToPageAfterSurnameValidation('/progress/:id/trackyourappeal', 'dwpAppealCaseId');
+  yield * I.goToPageAfterSurnameValidation('/trackyourappeal/:id', 'dwpAppealCaseId');
   I.see('Mr. B Bravo');
   I.see('Appeal reference number: SC222/22/22222');
   I.see(pageText.progressBar.screenReader.appeal.happened);
@@ -34,7 +34,7 @@ Scenario('verify appellant details after DWP response received', function*(I, Pr
 });
 
 Scenario('verify appellant details after Hearing Booked', function*(I, Properties) {
-  yield * I.goToPageAfterSurnameValidation('/progress/:id/trackyourappeal', 'hearingBookedAppealCaseId');
+  yield * I.goToPageAfterSurnameValidation('/trackyourappeal/:id', 'hearingBookedAppealCaseId');
   I.see('Mr. C Charlie');
   I.see('Appeal reference number: SC333/33/33333');
   I.see(pageText.progressBar.screenReader.appeal.happened);
@@ -71,7 +71,7 @@ Scenario('verify hearing details', function*(I) {
 
 Scenario('verify appellant details after Hearing response received for ESA appeal', function*(I) {
   const date = yield I.calcAppealDate("hearingESAAppealCaseId", 0);
-  yield * I.goToPageAfterSurnameValidation('/progress/:id/trackyourappeal', 'hearingESAAppealCaseId');
+  yield * I.goToPageAfterSurnameValidation('/trackyourappeal/:id', 'hearingESAAppealCaseId');
   I.see('Ms. D Delta');
   I.see('Appeal reference number: SC444/44/44444');
   I.see(pageText.progressBar.screenReader.appeal.happened);
@@ -84,7 +84,7 @@ Scenario('verify appellant details after Hearing response received for ESA appea
 
 Scenario('verify appellant details after Hearing response received for PIP appeal', function*(I) {
   const date = yield I.calcAppealDate("hearingPIPAppealCaseId", 0);
-  yield * I.goToPageAfterSurnameValidation('/progress/:id/trackyourappeal', 'hearingPIPAppealCaseId');
+  yield * I.goToPageAfterSurnameValidation('/trackyourappeal/:id', 'hearingPIPAppealCaseId');
   I.see('Ms. D Date');
   I.see('Appeal reference number: SC300/04/44444');
   I.see(pageText.progressBar.screenReader.appeal.happened);
@@ -96,17 +96,17 @@ Scenario('verify appellant details after Hearing response received for PIP appea
  });
 
 Scenario('verify about your appeal section links', function*(I) {
-  yield * I.goToPageAfterSurnameValidation('/progress/:id/trackyourappeal', 'hearingESAAppealCaseId');
+  yield * I.goToPageAfterSurnameValidation('/trackyourappeal/:id', 'hearingESAAppealCaseId');
   I.see('About your appeal');
   I.click('What to expect at your hearing');
   I.see('What to expect at your hearing');
-  I.amOnPage('/progress/' + appealId + '/trackyourappeal');
+  I.amOnPage('/trackyourappeal/' + appealId);
   I.click('Claiming hearing expenses');
   I.see('Claiming expenses to attend your hearing');
-  I.amOnPage('/progress/' + appealId + '/trackyourappeal');
+  I.amOnPage('/trackyourappeal/' + appealId);
   I.click('Providing evidence to support your appeal');
   I.see('Providing evidence to support your appeal');
-  I.amOnPage('/progress/' + appealId + '/trackyourappeal');
+  I.amOnPage('/trackyourappeal/' + appealId);
   I.click('Contact us');
   I.see('Contact us');
   I.see('Cookie');
@@ -163,7 +163,7 @@ Scenario('verify contact us page', function*(I) {
 });
 
 Scenario('verify appellant details for lapsed revised state for ESA appeal', function*(I) {
-  yield * I.goToPageAfterSurnameValidation('/progress/:id/trackyourappeal', 'lapsedRevisedESAAppealCaseId');
+  yield * I.goToPageAfterSurnameValidation('/trackyourappeal/:id', 'lapsedRevisedESAAppealCaseId');
   I.see('Ms. F Foxtrot');
   I.see('Appeal reference number: SC555/55/55555');
   I.see('DWP have told us they changed their decision on your entitlement to ESA in your favour. We’ve therefore closed this appeal. If you don’t agree with their new decision you can start a new appeal.');
@@ -172,7 +172,7 @@ Scenario('verify appellant details for lapsed revised state for ESA appeal', fun
 });
 
 Scenario('verify appellant details for lapsed revised state for PIP appeal', function*(I) {
-  yield * I.goToPageAfterSurnameValidation('/progress/:id/trackyourappeal', 'lapsedRevisedPIPAppealCaseId');
+  yield * I.goToPageAfterSurnameValidation('/trackyourappeal/:id', 'lapsedRevisedPIPAppealCaseId');
   I.see('Ms. F Fruit');
   I.see('Appeal reference number: SC300/05/55555');
   I.see('DWP have told us they changed their decision on your entitlement to PIP in your favour. We’ve therefore closed this appeal. If you don’t agree with their new decision you can start a new appeal.');
@@ -181,7 +181,7 @@ Scenario('verify appellant details for lapsed revised state for PIP appeal', fun
 });
 
 Scenario('verify appellant details for withdrawn state for ESA appeal', function*(I) {
-  yield * I.goToPageAfterSurnameValidation('/progress/:id/trackyourappeal', 'withdrawnESAAppealCaseId');
+  yield * I.goToPageAfterSurnameValidation('/trackyourappeal/:id', 'withdrawnESAAppealCaseId');
   I.see('Ms. I Iglo');
   I.see('Appeal reference number: SC666/66/66666');
   I.see(pageText.status.withdrawn.content[0]);
@@ -190,7 +190,7 @@ Scenario('verify appellant details for withdrawn state for ESA appeal', function
 });
 
 Scenario('verify appellant details for withdrawn state for PIP appeal', function*(I) {
-  yield * I.goToPageAfterSurnameValidation('/progress/:id/trackyourappeal', 'withdrawnPIPAppealCaseId');
+  yield * I.goToPageAfterSurnameValidation('/trackyourappeal/:id', 'withdrawnPIPAppealCaseId');
   I.see('Ms. I Iceberg');
   I.see('Appeal reference number: SC300/06/66666');
   I.see(pageText.status.withdrawn.content[0]);
@@ -200,7 +200,7 @@ Scenario('verify appellant details for withdrawn state for PIP appeal', function
 
 Scenario('verify appellant details for adjourned state', function*(I) {
   const date = yield I.calcAppealDate("adjurnedAppealCaseId", 7);
-  yield * I.goToPageAfterSurnameValidation('/progress/:id/trackyourappeal', 'adjurnedAppealCaseId');
+  yield * I.goToPageAfterSurnameValidation('/trackyourappeal/:id', 'adjurnedAppealCaseId');
   I.see('Ms. K Kilo');
   I.see('Appeal reference number: SC777/77/77777');
   I.see(pageText.progressBar.screenReader.appeal.happened);
@@ -211,7 +211,7 @@ Scenario('verify appellant details for adjourned state', function*(I) {
 });
 
 Scenario('verify appellant details for postponed state for ESA appeal', function*(I) {
-  yield * I.goToPageAfterSurnameValidation('/progress/:id/trackyourappeal', 'postponedESAAppealCaseId');
+  yield * I.goToPageAfterSurnameValidation('/trackyourappeal/:id', 'postponedESAAppealCaseId');
   I.see('Ms. L Lena');
   I.see('Appeal reference number: SC888/88/88888');
   I.see(pageText.progressBar.screenReader.appeal.happened);
@@ -223,7 +223,7 @@ Scenario('verify appellant details for postponed state for ESA appeal', function
 });
 
 Scenario('verify appellant details for postponed state PIP appeal', function*(I) {
-  yield * I.goToPageAfterSurnameValidation('/progress/:id/trackyourappeal', 'postponedPIPAppealCaseId');
+  yield * I.goToPageAfterSurnameValidation('/trackyourappeal/:id', 'postponedPIPAppealCaseId');
   I.see('Ms. L Lemon');
   I.see('Appeal reference number: SC300/08/88888');
   I.see(pageText.progressBar.screenReader.appeal.happened);
@@ -235,7 +235,7 @@ Scenario('verify appellant details for postponed state PIP appeal', function*(I)
 });
 
 Scenario('verify appellant details for past hearing date state for ESA appeal', function*(I) {
-  yield * I.goToPageAfterSurnameValidation('/progress/:id/trackyourappeal', 'pastHearingDateESAAppealCaseId');
+  yield * I.goToPageAfterSurnameValidation('/trackyourappeal/:id', 'pastHearingDateESAAppealCaseId');
   I.see('Mr. M Miao');
   I.see('Appeal reference number: SC100/00/00000');
   I.see(pageText.progressBar.screenReader.appeal.happened);
@@ -247,7 +247,7 @@ Scenario('verify appellant details for past hearing date state for ESA appeal', 
 });
 
 Scenario('verify appellant details for past hearing date state for PIP appeal', function*(I) {
-  yield * I.goToPageAfterSurnameValidation('/progress/:id/trackyourappeal', 'pastHearingDatePIPAppealCaseId');
+  yield * I.goToPageAfterSurnameValidation('/trackyourappeal/:id', 'pastHearingDatePIPAppealCaseId');
   I.see('Mr. M Melon');
   I.see('Appeal reference number: SC300/10/00000');
   I.see(pageText.progressBar.screenReader.appeal.happened);
@@ -260,7 +260,7 @@ Scenario('verify appellant details for past hearing date state for PIP appeal', 
 
 Scenario('verify appellant details for dormant state for ESA appeal', function*(I) {
   const date = yield I.calcAppealDate("dormantESAAppealCaseId", 0);
-  yield * I.goToPageAfterSurnameValidation('/progress/:id/trackyourappeal', 'dormantESAAppealCaseId');
+  yield * I.goToPageAfterSurnameValidation('/trackyourappeal/:id', 'dormantESAAppealCaseId');
   I.see('Mr. N November');
   I.see('Appeal reference number: SC100/00/00001');
   I.see('A hearing for your ESA appeal took place on '+date+' and a decision was made. You should receive the decision by post within 7 working days of the hearing.');
@@ -269,7 +269,7 @@ Scenario('verify appellant details for dormant state for ESA appeal', function*(
 
 Scenario('verify appellant details for dormant state for PIP appeal', function*(I) {
   const date = yield I.calcAppealDate("dormantPIPAppealCaseId", 0);
-  yield * I.goToPageAfterSurnameValidation('/progress/:id/trackyourappeal', 'dormantPIPAppealCaseId');
+  yield * I.goToPageAfterSurnameValidation('/trackyourappeal/:id', 'dormantPIPAppealCaseId');
   I.see('Mr. N Nut');
   I.see('Appeal reference number: SC300/11/00001');
   I.see('A hearing for your PIP appeal took place on '+date+' and a decision was made. You should receive the decision by post within 7 working days of the hearing.');
@@ -277,7 +277,7 @@ Scenario('verify appellant details for dormant state for PIP appeal', function*(
 });
 
 Scenario('verify appellant details for Closed state', function*(I) {
-  yield * I.goToPageAfterSurnameValidation('/progress/:id/trackyourappeal', 'dormantClosedESAAppealCaseId');
+  yield * I.goToPageAfterSurnameValidation('/trackyourappeal/:id', 'dormantClosedESAAppealCaseId');
   I.see('Mr. O Owl');
   I.see('Appeal reference number: SC100/00/00002');
   I.see('Your ESA benefit appeal is now closed.');
@@ -285,7 +285,7 @@ Scenario('verify appellant details for Closed state', function*(I) {
 });
 
 Scenario('verify appellant details for Closed state', function*(I) {
-  yield * I.goToPageAfterSurnameValidation('/progress/:id/trackyourappeal', 'dormantClosedPIPAppealCaseId');
+  yield * I.goToPageAfterSurnameValidation('/trackyourappeal/:id', 'dormantClosedPIPAppealCaseId');
   I.see('Mr. O Opel');
   I.see('Appeal reference number: SC300/12/00002');
   I.see('Your PIP benefit appeal is now closed.');
@@ -293,7 +293,7 @@ Scenario('verify appellant details for Closed state', function*(I) {
 });
 
 Scenario('verify appellant details for dwp respond overdue state', function*(I) {
-  yield * I.goToPageAfterSurnameValidation('/progress/:id/trackyourappeal', 'dwpRespondOverdueAppealCaseId');
+  yield * I.goToPageAfterSurnameValidation('/trackyourappeal/:id', 'dwpRespondOverdueAppealCaseId');
   I.see('Mr. P Papa');
   I.see('Appeal reference number: SC100/00/00003');
   I.see(pageText.progressBar.screenReader.appeal.happened);
@@ -305,7 +305,7 @@ Scenario('verify appellant details for dwp respond overdue state', function*(I) 
 
 
 Scenario('verify appellant details for new hearing booked state', function*(I) {
-  yield * I.goToPageAfterSurnameValidation('/progress/:id/trackyourappeal', 'newHearingBookedAppealCaseId');
+  yield * I.goToPageAfterSurnameValidation('/trackyourappeal/:id', 'newHearingBookedAppealCaseId');
   I.see('Ms. Q Quack');
   I.see('Appeal reference number: SC100/00/00004');
   I.see(pageText.progressBar.screenReader.appeal.happened);

--- a/test/smoke/scenarios/track_appeal/trackAppealPages.js
+++ b/test/smoke/scenarios/track_appeal/trackAppealPages.js
@@ -115,7 +115,7 @@ Scenario('verify about your appeal section links', function*(I) {
 });
 
 Scenario('verify evidence page', function*(I) {
-  yield * I.goToPageAfterSurnameValidation('/progress/:id/evidence', 'hearingESAAppealCaseId');
+  yield * I.goToPageAfterSurnameValidation('/evidence/:id', 'hearingESAAppealCaseId');
   I.see(pageText.evidence.provide.title);
   I.see(pageText.evidence.provide.medicalEvidence.heading);
   I.see(pageText.evidence.provide.oralEvidence.heading);

--- a/test/smoke/scenarios/track_appeal/trackAppealPages.js
+++ b/test/smoke/scenarios/track_appeal/trackAppealPages.js
@@ -128,7 +128,7 @@ Scenario('verify evidence page', function*(I) {
 });
 
 Scenario('verify what to expect at your hearing page for an ESA appeal', function*(I) {
-  yield * I.goToPageAfterSurnameValidation('/progress/:id/abouthearing', 'hearingESAAppealCaseId');
+  yield * I.goToPageAfterSurnameValidation('/abouthearing/:id', 'hearingESAAppealCaseId');
   I.see(pageText.hearing.details.title);
   I.see('Your hearing is an opportunity for you to explain your appeal and get an impartial decision on your entitlement to Employment and Support Allowance (ESA). The tribunal is independent and will consider both sides of the appeal.');
   I.see('An ESA appeal hearing with a judge and a medical expert.');

--- a/test/smoke/scenarios/track_appeal/trackAppealPages.js
+++ b/test/smoke/scenarios/track_appeal/trackAppealPages.js
@@ -145,7 +145,7 @@ Scenario('verify what to expect at your hearing page for an ESA appeal', functio
   });
 
 Scenario('verify expenses page', function*(I) {
-  yield * I.goToPageAfterSurnameValidation('/progress/:id/expenses', 'hearingESAAppealCaseId');
+  yield * I.goToPageAfterSurnameValidation('/expenses/:id', 'hearingESAAppealCaseId');
   I.see(pageText.claimExpenses.title);
   I.see(pageText.claimExpenses.content);
 });

--- a/test/smoke/scenarios/track_appeal/trackAppealPages.js
+++ b/test/smoke/scenarios/track_appeal/trackAppealPages.js
@@ -151,7 +151,7 @@ Scenario('verify expenses page', function*(I) {
 });
 
 Scenario('verify contact us page', function*(I) {
-  yield * I.goToPageAfterSurnameValidation('/progress/:id/contactus', 'hearingESAAppealCaseId');
+  yield * I.goToPageAfterSurnameValidation('/contactus/:id', 'hearingESAAppealCaseId');
   I.see('Contact us');
   I.see(pageText.contactUs.title);
   I.see(pageText.contactUs.description);

--- a/test/smoke/scenarios/validate_surname/validateSurname.js
+++ b/test/smoke/scenarios/validate_surname/validateSurname.js
@@ -18,7 +18,7 @@ Scenario('When I enter the correct surname that matches to the mactoken, I am ta
 
   I.fillField('#surname', data.appeal.surname);
   I.click(validateSurnameContent.submit);
-  I.seeInCurrentUrl(`/progress/${appealId}/trackyourappeal`);
+  I.seeInCurrentUrl(`/trackyourappeal/${appealId}`);
 
 });
 

--- a/test/unit/routes.test.js
+++ b/test/unit/routes.test.js
@@ -56,8 +56,8 @@ describe('routes.js', () => {
         .expect(HttpStatus.MOVED_TEMPORARILY, done);
     });
 
-    it('should respond to /progress/md002/contactus', (done) => {
-      url = '/progress/md002/contactus';
+    it('should respond to /contactus/md002', (done) => {
+      url = '/contactus/md002';
       request(app)
         .get(url)
         .expect('Location', '/validate-surname/md002')

--- a/test/unit/routes.test.js
+++ b/test/unit/routes.test.js
@@ -16,8 +16,8 @@ describe('routes.js', () => {
         .expect(HttpStatus.MOVED_TEMPORARILY, done);
     });
 
-    it('should respond to /progress/md002/expenses', (done) => {
-      url = '/progress/md002/expenses';
+    it('should respond to /expenses/md002', (done) => {
+      url = '/expenses/md002';
       request(app)
         .get(url)
         .expect('Location', '/validate-surname/md002')

--- a/test/unit/routes.test.js
+++ b/test/unit/routes.test.js
@@ -40,8 +40,8 @@ describe('routes.js', () => {
         .expect(HttpStatus.MOVED_TEMPORARILY, done);
     });
 
-    it('should respond to /progress/md002/evidence', (done) => {
-      url = '/progress/md002/evidence';
+    it('should respond to /evidence/md002', (done) => {
+      url = '/evidence/md002';
       request(app)
         .get(url)
         .expect('Location', '/validate-surname/md002')

--- a/test/unit/routes.test.js
+++ b/test/unit/routes.test.js
@@ -24,16 +24,16 @@ describe('routes.js', () => {
         .expect(HttpStatus.MOVED_TEMPORARILY, done);
     });
 
-    it('should respond to /progress/md007/hearingdetails', (done) => {
-      url = '/progress/md007/hearingdetails';
+    it('should respond to /hearingdetails/md007', (done) => {
+      url = '/hearingdetails/md007';
       request(app)
         .get(url)
         .expect('Location', '/validate-surname/md007')
         .expect(HttpStatus.MOVED_TEMPORARILY, done);
     });
 
-    it('should respond to /progress/md007/hearingdetails/10', (done) => {
-      url = '/progress/md007/hearingdetails/10';
+    it('should respond to /hearingdetails/md007/10', (done) => {
+      url = '/hearingdetails/md007/10';
       request(app)
         .get(url)
         .expect('Location', '/validate-surname/md007')

--- a/test/unit/routes.test.js
+++ b/test/unit/routes.test.js
@@ -48,8 +48,8 @@ describe('routes.js', () => {
         .expect(HttpStatus.MOVED_TEMPORARILY, done);
     });
 
-    it('should respond to /progress/md002/trackyourappeal', (done) => {
-      url = '/progress/md002/trackyourappeal';
+    it('should respond to /trackyourappeal/md002', (done) => {
+      url = '/trackyourappeal/md002';
       request(app)
         .get(url)
         .expect('Location', '/validate-surname/md002')
@@ -191,7 +191,7 @@ describe('routes.js', () => {
 
     it('should respond to an unknown id with a HTTP 404:Not found', (done) => {
       request(app)
-        .get('/progress/999/trackyourappeal')
+        .get('/trackyourappeal/999')
         .expect(HttpStatus.MOVED_TEMPORARILY, done);
     });
 

--- a/test/unit/routes.test.js
+++ b/test/unit/routes.test.js
@@ -8,8 +8,8 @@ describe('routes.js', () => {
 
     let url;
 
-    it('should respond to /progress/md002/abouthearing', (done) => {
-      url = '/progress/md002/abouthearing';
+    it('should respond to /abouthearing/md002', (done) => {
+      url = '/abouthearing/md002';
       request(app)
         .get(url)
         .expect('Location', '/validate-surname/md002')

--- a/test/unit/services/matchSurnameToAppeal.test.js
+++ b/test/unit/services/matchSurnameToAppeal.test.js
@@ -53,7 +53,7 @@ describe('matchSurnameToAppeal.js', () => {
 
       return matchSurnameToAppeal(req, res, next)
         .then(() => {
-          expect(res.redirect).to.have.been.calledWith(`/progress/${req.params.id}/trackyourappeal`);
+          expect(res.redirect).to.have.been.calledWith(`/trackyourappeal/${req.params.id}`);
         });
 
     });

--- a/test/unit/templates/trackYourAppeal.test.js
+++ b/test/unit/templates/trackYourAppeal.test.js
@@ -44,7 +44,7 @@ describe('Track your appeal template', () => {
 
   describe('how the class \'active\' is added to the progress bar when the status is APPEAL_RECEIVED', () => {
 
-    const url = '/progress/md002/trackyourappeal';
+    const url = '/trackyourappeal/md002';
 
     it('should add the \'active\' class to appeal received', (done) => {
       requestPageAndAssertActive(url, '.appeal-received', true, done);
@@ -66,7 +66,7 @@ describe('Track your appeal template', () => {
 
   describe('how the class \'active\' is added to the progress bar when the status is DWP_RESPOND', () => {
 
-    const url = '/progress/md005/trackyourappeal';
+    const url = '/trackyourappeal/md005';
 
     it('should add the \'active\' class to appeal received', (done) => {
       requestPageAndAssertActive(url, '.appeal-received', true, done);
@@ -88,7 +88,7 @@ describe('Track your appeal template', () => {
 
   describe('how the class \'active\' is added to the progress bar when the status is HEARING_BOOKED', () => {
 
-    const url = '/progress/md008/trackyourappeal';
+    const url = '/trackyourappeal/md008';
 
     it('should add the \'active\' class to appeal received', (done) => {
       requestPageAndAssertActive(url, '.appeal-received', true, done);
@@ -110,7 +110,7 @@ describe('Track your appeal template', () => {
 
   describe('how the class \'active\' is added to the progress bar when the status is HEARING', () => {
 
-    const url = '/progress/md007/trackyourappeal';
+    const url = '/trackyourappeal/md007';
 
     it('should add the \'active\' class to appeal received', (done) => {
       requestPageAndAssertActive(url, '.appeal-received', true, done);


### PR DESCRIPTION
# Updated all TYA route paths for better Google Analalytics

## From:
`/progress/:id/abouthearing`
`/progress/:id/trackyourappeal`
`/progress/:id/evidence`
`/progress/:id/expenses`
`/progress/:id/hearingdetails`
`/progress/:id/hearingdetails/:index`
`/progress/:id/contactus`

## To:
`/abouthearing/:id`
`/trackyourappeal/:id`
`/evidence/:id`
`/expenses/:id`
`/hearingdetails/:id`
`/hearingdetails/:id/:index`
`/contactus/:id`
