### PR TITLE
SSCS-535 Where to send evidence

### DIFF
--- a/app/views/provide-evidence.html
+++ b/app/views/provide-evidence.html
@@ -34,9 +34,14 @@ Provide Evidence
             {% for content in i18n.evidence.provide.whereToSendEvidence.content %}
             <p>{{content}}</p>
             {% endfor %}
-            {% for addressLine in i18n.evidence.provide.whereToSendEvidence.address %}
-            <div>{{addressLine}}</div>
-            {% endfor %}
+
+            <div>
+                {% for addressLine in data.regionalProcessingCenter.addressLines %}
+                    {{ addressLine }}<br>
+                {% endfor %}
+                {{ data.regionalProcessingCenter.city | capitalize }}<br>
+                {{ data.regionalProcessingCenter.postcode }}
+            </div>
 
         </div>
 

--- a/test/mock/data/adjourned.json
+++ b/test/mock/data/adjourned.json
@@ -28,6 +28,19 @@
         "type": "HEARING_BOOKED",
         "contentKey": "status.hearingBooked"
       }
-    ]
+    ],
+    "regionalProcessingCenter": {
+      "name": "LIVERPOOL",
+      "addressLines": [
+        "HM Courts & Tribunals Service",
+        "Social Security & Child Support Appeals",
+        "Prudential Buildings",
+        "36 Dale Street"
+      ],
+      "city": "LIVERPOOL",
+      "postcode": "L2 5UZ",
+      "phoneNumber": "0300 123 1142",
+      "faxNumber": "0870 324 0109"
+    }
   }
 }

--- a/test/mock/data/appealReceived.json
+++ b/test/mock/data/appealReceived.json
@@ -19,6 +19,19 @@
         "dwpResponseDate": "2017-04-12T00:00:00Z",
         "contentKey": "status.appealReceived"
       }
-    ]
+    ],
+    "regionalProcessingCenter": {
+      "name": "BIRMINGHAM",
+      "addressLines": [
+        "HM Courts & Tribunals Service",
+        "Social Security & Child Support Appeals",
+        "Administrative Support Centre",
+        "PO Box 14620"
+      ],
+      "city": "BIRMINGHAM",
+      "postcode": "B16 6FR",
+      "phoneNumber": "0300 123 1142",
+      "faxNumber": "0126 434 7983"
+    }
   }
 }

--- a/test/mock/data/closed.json
+++ b/test/mock/data/closed.json
@@ -11,6 +11,19 @@
         "type": "CLOSED",
         "contentKey": "status.closed"
       }
-    ]
+    ],
+    "regionalProcessingCenter": {
+      "name": "CARDIFF",
+      "addressLines": [
+        "HM Courts & Tribunals Service",
+        "Social Security & Child Support Appeals",
+        "Eastgate House",
+        "Newport Road"
+      ],
+      "city": "CARDIFF",
+      "postcode": "CF24 0AB",
+      "phoneNumber": "0300 123 1142",
+      "faxNumber": "0870 739 4438"
+    }
   }
 }

--- a/test/mock/data/dormant.json
+++ b/test/mock/data/dormant.json
@@ -13,6 +13,19 @@
         "type": "DORMANT",
         "contentKey": "status.dormant"
       }
-    ]
+    ],
+    "regionalProcessingCenter": {
+      "name": "LEEDS",
+      "addressLines": [
+        "HM Courts & Tribunals Service",
+        "Social Security & Child Support Appeals",
+        "York House",
+        "31 York Place"
+      ],
+      "city": "LEEDS",
+      "postcode": "LS1 2ED",
+      "phoneNumber": "0300 123 1142",
+      "faxNumber": "0870 739 4331"
+    }
   }
 }

--- a/test/mock/data/dwpRespond.json
+++ b/test/mock/data/dwpRespond.json
@@ -32,6 +32,19 @@
         "dwpResponseDate": "2017-04-12T00:00:00Z",
         "contentKey": "status.appealReceived"
       }
-    ]
+    ],
+    "regionalProcessingCenter": {
+      "name": "SUTTON",
+      "addressLines": [
+        "HM Courts & Tribunals Service",
+        "Social Security & Child Support Appeals",
+        "Copthall House",
+        "9 The Pavement, Grove Road"
+      ],
+      "city": "SUTTON",
+      "postcode": "SM1 1DA",
+      "phoneNumber": "0300 123 1142",
+      "faxNumber": "0870 739 4229"
+    }
   }
 }

--- a/test/mock/data/dwpRespondOverdue.json
+++ b/test/mock/data/dwpRespondOverdue.json
@@ -21,6 +21,19 @@
         "type": "APPEAL_RECEIVED",
         "contentKey": "status.appealReceived"
       }
-    ]
+    ],
+    "regionalProcessingCenter": {
+      "name": "NEWCASTLE",
+      "addressLines": [
+        "HM Courts & Tribunals Service",
+        "Social Security & Child Support Appeals",
+        "Manorview House",
+        "Kings Manor"
+      ],
+      "city": "NEWCASTLE UPON TYNE",
+      "postcode": "NE1 6PA",
+      "phoneNumber": "0300 123 1142",
+      "faxNumber": "0870 739 5784"
+    }
   }
 }

--- a/test/mock/data/hearing.json
+++ b/test/mock/data/hearing.json
@@ -65,6 +65,19 @@
         "type": "APPEAL_RECEIVED",
         "contentKey": "status.appealReceived"
       }
-    ]
+    ],
+    "regionalProcessingCenter": {
+      "name": "LIVERPOOL",
+      "addressLines": [
+        "HM Courts & Tribunals Service",
+        "Social Security & Child Support Appeals",
+        "Prudential Buildings",
+        "36 Dale Street"
+      ],
+      "city": "LIVERPOOL",
+      "postcode": "L2 5UZ",
+      "phoneNumber": "0300 123 1142",
+      "faxNumber": "0870 324 0109"
+    }
   }
 }

--- a/test/mock/data/hearingBooked.json
+++ b/test/mock/data/hearingBooked.json
@@ -40,6 +40,19 @@
         "type": "APPEAL_RECEIVED",
         "contentKey": "status.appealReceived"
       }
-    ]
+    ],
+    "regionalProcessingCenter": {
+      "name": "BIRMINGHAM",
+      "addressLines": [
+        "HM Courts & Tribunals Service",
+        "Social Security & Child Support Appeals",
+        "Administrative Support Centre",
+        "PO Box 14620"
+      ],
+      "city": "BIRMINGHAM",
+      "postcode": "B16 6FR",
+      "phoneNumber": "0300 123 1142",
+      "faxNumber": "0126 434 7983"
+    }
   }
 }

--- a/test/mock/data/lapsedRevised.json
+++ b/test/mock/data/lapsedRevised.json
@@ -57,6 +57,19 @@
         "type": "HEARING_BOOKED",
         "contentKey": "status.hearingBooked"
       }
-    ]
+    ],
+    "regionalProcessingCenter": {
+      "name": "BIRMINGHAM",
+      "addressLines": [
+        "HM Courts & Tribunals Service",
+        "Social Security & Child Support Appeals",
+        "Administrative Support Centre",
+        "PO Box 14620"
+      ],
+      "city": "BIRMINGHAM",
+      "postcode": "B16 6FR",
+      "phoneNumber": "0300 123 1142",
+      "faxNumber": "0126 434 7983"
+    }
   }
 }

--- a/test/mock/data/newHearingBooked.json
+++ b/test/mock/data/newHearingBooked.json
@@ -29,6 +29,19 @@
         "type": "ADJOURNED",
         "contentKey": "status.adjourned"
       }
-    ]
+    ],
+    "regionalProcessingCenter": {
+      "name": "CARDIFF",
+      "addressLines": [
+        "HM Courts & Tribunals Service",
+        "Social Security & Child Support Appeals",
+        "Eastgate House",
+        "Newport Road"
+      ],
+      "city": "CARDIFF",
+      "postcode": "CF24 0AB",
+      "phoneNumber": "0300 123 1142",
+      "faxNumber": "0870 739 4438"
+    }
   }
 }

--- a/test/mock/data/pastHearingBooked.json
+++ b/test/mock/data/pastHearingBooked.json
@@ -21,6 +21,19 @@
         "type": "APPEAL_RECEIVED",
         "contentKey": "status.appealReceived"
       }
-    ]
+    ],
+    "regionalProcessingCenter": {
+      "name": "LEEDS",
+      "addressLines": [
+        "HM Courts & Tribunals Service",
+        "Social Security & Child Support Appeals",
+        "York House",
+        "31 York Place"
+      ],
+      "city": "LEEDS",
+      "postcode": "LS1 2ED",
+      "phoneNumber": "0300 123 1142",
+      "faxNumber": "0870 739 4331"
+    }
   }
 }

--- a/test/mock/data/postponed.json
+++ b/test/mock/data/postponed.json
@@ -27,6 +27,19 @@
         "type": "HEARING_BOOKED",
         "contentKey": "status.hearingBooked"
       }
-    ]
+    ],
+    "regionalProcessingCenter": {
+      "name": "SUTTON",
+      "addressLines": [
+        "HM Courts & Tribunals Service",
+        "Social Security & Child Support Appeals",
+        "Copthall House",
+        "9 The Pavement, Grove Road"
+      ],
+      "city": "SUTTON",
+      "postcode": "SM1 1DA",
+      "phoneNumber": "0300 123 1142",
+      "faxNumber": "0870 739 4229"
+    }
   }
 }

--- a/test/mock/data/withdrawn.json
+++ b/test/mock/data/withdrawn.json
@@ -12,6 +12,19 @@
         "type": "WITHDRAWN",
         "contentKey": "status.withdrawn"
       }
-    ]
+    ],
+    "regionalProcessingCenter": {
+      "name": "LIVERPOOL",
+      "addressLines": [
+        "HM Courts & Tribunals Service",
+        "Social Security & Child Support Appeals",
+        "Prudential Buildings",
+        "36 Dale Street"
+      ],
+      "city": "LIVERPOOL",
+      "postcode": "L2 5UZ",
+      "phoneNumber": "0300 123 1142",
+      "faxNumber": "0870 324 0109"
+    }
   }
 }


### PR DESCRIPTION
- Add html to provide-evidence template to display the address of where the user should send their evidence.
- This data comes from the api
- Add the data to the mock json files