### PR TITLE
SSCS-2883 Insecure surname cookie

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -171,6 +171,13 @@ module.exports = function(grunt){
       'concurrent:target'
     ]);
 
+    grunt.registerTask('dev-mock-services-debug', [
+      'env:dev',
+      'sync',
+      'sass',
+      'copy:mockServices'
+    ]);
+
     grunt.registerTask('generate-assets', [
       'sync',
       'sass',

--- a/app/middleware/surnameValidationCookieCheck.js
+++ b/app/middleware/surnameValidationCookieCheck.js
@@ -1,5 +1,9 @@
+
 const surnameValidationCookieCheck = (req, res, next) => {
-  req.session.surnameHasValidated ? next() : res.redirect(`/validate-surname/${req.params.id}`);
+
+  const surnameHasValidated = req.session[req.params.id];
+
+  surnameHasValidated ? next() : res.redirect(`/validate-surname/${req.params.id}`);
 };
 
 module.exports = { surnameValidationCookieCheck };

--- a/app/services/matchSurnameToAppeal.js
+++ b/app/services/matchSurnameToAppeal.js
@@ -9,11 +9,10 @@ const matchSurnameToAppeal = (req, res, next) => {
 
   return request.get(`${api}/appeals/${id}/surname/${surname}`)
     .then(() => {
-      req.session.surnameHasValidated = true;
+      req.session[id] = true;
       res.redirect(`/trackyourappeal/${id}`);
     })
     .catch(error => {
-      req.session.surnameHasValidated = false;
       if (error.statusCode === HttpStatus.BAD_REQUEST) {
         res.status(HttpStatus.BAD_REQUEST);
         res.render('validate-surname', {

--- a/test/mock/mockMatchSurnameToAppealService.js
+++ b/test/mock/mockMatchSurnameToAppealService.js
@@ -1,15 +1,25 @@
 const mockedData = require('test/mock/data/index');
 const HttpStatus = require('http-status-codes');
 
+const getMockedAppeal = (appealNumber) => {
+
+  const mockedAppeal = mockedData[appealNumber];
+
+  if(!mockedAppeal) {
+    throw new ReferenceError(`Unknown mocked appeal number '${appealNumber}'`);
+  }
+
+  return mockedAppeal.appeal;
+};
+
 const matchSurnameToAppeal = (req, res) => {
 
-  const mockedAppeal = mockedData[req.params.id].appeal;
+  const mockedAppeal = getMockedAppeal(req.params.id);
   const id = req.params.id;
   const surname = req.body.surname;
-  const surnameHasValidated = mockedAppeal.surname.toLowerCase() === surname.toLowerCase();
 
-  if (surnameHasValidated) {
-    req.session.surnameHasValidated = true;
+  if (mockedAppeal.surname.toLowerCase() === surname.toLowerCase()) {
+    req.session[id] = true;
     res.redirect(`/trackyourappeal/${id}`);
   } else {
     res.status(HttpStatus.BAD_REQUEST);
@@ -28,4 +38,4 @@ const matchSurnameToAppeal = (req, res) => {
   }
 };
 
-module.exports = { matchSurnameToAppeal };
+module.exports = { matchSurnameToAppeal, getMockedAppeal };

--- a/test/unit/services/matchSurnameToAppeal.test.js
+++ b/test/unit/services/matchSurnameToAppeal.test.js
@@ -52,6 +52,7 @@ describe('matchSurnameToAppeal.js', () => {
       return matchSurnameToAppeal(req, res, next)
         .then(() => {
           expect(res.redirect).to.have.been.calledWith(`/trackyourappeal/${req.params.id}`);
+          expect(req.session).to.have.property(req.params.id).that.equals(true);
         });
 
     });
@@ -86,6 +87,7 @@ describe('matchSurnameToAppeal.js', () => {
               }
             }
           });
+          expect(req.session).to.not.have.property(req.params.id);
         });
 
     });
@@ -101,6 +103,7 @@ describe('matchSurnameToAppeal.js', () => {
       return matchSurnameToAppeal(req, res, next)
         .catch(() => {
           expect(next).to.have.been.calledWith(error);
+          expect(req.session).to.not.have.property(req.params.id);
         });
 
     });


### PR DESCRIPTION
Previously TYA access would be granted via a cookie when Alice supplied her appeal number (i.e. a 10 digit alpha numeric string) and a matching surname, however, Bob could then access his own appeal using his own appeal number without supplying his surname. This fix ensures both Alice and Bob provide both their unique appeals numbers and their corresponding surnames.