### PR TITLE
Display surname validation error messages and the 404 error page

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -102,9 +102,6 @@ module.exports = grunt => {
         ]
       }
     },
-
-    env: { dev: { NODE_PATH: '.' } },
-
     copy: {
       services: {
         src: 'app/assets/javascripts/index.js',
@@ -154,7 +151,6 @@ module.exports = grunt => {
 
   [
     'grunt-nsp',
-    'grunt-env',
     'grunt-sync',
     'grunt-contrib-watch',
     'grunt-contrib-copy',
@@ -166,26 +162,15 @@ module.exports = grunt => {
   });
 
   grunt.registerTask('dev', [
-    'env:dev',
-    'sync',
-    'sass',
-    'copy:services',
+    'generate-assets',
     'concurrent:target'
   ]);
 
   grunt.registerTask('dev-mock-services', [
-    'env:dev',
     'sync',
     'sass',
     'copy:mockServices',
     'concurrent:target'
-  ]);
-
-  grunt.registerTask('dev-mock-services-debug', [
-    'env:dev',
-    'sync',
-    'sass',
-    'copy:mockServices'
   ]);
 
   grunt.registerTask('generate-assets', [

--- a/app.js
+++ b/app.js
@@ -122,13 +122,7 @@ app.use(cookieSession({
 
 app.use(locals);
 app.use('/', routes);
-
 app.use(ErrorHandling.handle404);
-
-if (process.env.NODE_ENV === 'development') {
-  app.use(ErrorHandling.handleErrorDuringDevelopment);
-} else {
-  app.use(ErrorHandling.handleError);
-}
+app.use(ErrorHandling.handleError);
 
 module.exports = app;

--- a/app/core/ErrorHandling.js
+++ b/app/core/ErrorHandling.js
@@ -1,7 +1,5 @@
+/* eslint-disable no-unused-vars  */
 const HttpStatus = require('http-status-codes');
-const { Logger } = require('@hmcts/nodejs-logging');
-
-const logger = Logger.getLogger('ErrorHandling.js');
 
 class ErrorHandling {
   static handle404(req, res, next) {
@@ -10,19 +8,10 @@ class ErrorHandling {
     next(error);
   }
 
-  static handleError(error, req, res) {
+  static handleError(error, req, res, next) {
     const status = ErrorHandling.getStatus(error);
     res.status(status);
     res.render(status === HttpStatus.NOT_FOUND ? 'errors/404.html' : 'errors/500.html');
-    logger.error(ErrorHandling.reformatError(error));
-  }
-
-  static handleErrorDuringDevelopment(error, req, res) {
-    const status = ErrorHandling.getStatus(error);
-    res.status(status);
-    const reformatedError = ErrorHandling.reformatError(error);
-    res.send(reformatedError);
-    logger.error(reformatedError);
   }
 
   static getStatus(error) {
@@ -30,22 +19,6 @@ class ErrorHandling {
            error.statusCode ||
            error.responseCode ||
            HttpStatus.INTERNAL_SERVER_ERROR;
-  }
-
-  static reformatError(error) {
-    const refErr = {
-      responseCode: error.status,
-      message: error.message
-    };
-
-    if (error.stack) {
-      refErr.stackTrace = error.stack.split('\n');
-      refErr.stackTrace = refErr.stackTrace.map(stackLine => {
-        return stackLine.trim();
-      });
-    }
-
-    return refErr;
   }
 }
 

--- a/app/services/matchSurnameToAppeal.js
+++ b/app/services/matchSurnameToAppeal.js
@@ -12,7 +12,7 @@ const matchSurnameToAppeal = (req, res, next) => {
       res.redirect(`/trackyourappeal/${id}`);
     })
     .catch(error => {
-      if (error.statusCode === HttpStatus.NOT_FOUND) {
+      if (error.status === HttpStatus.NOT_FOUND) {
         res.status(HttpStatus.NOT_FOUND);
         res.render('validate-surname', {
           id,

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "grunt-concurrent": "^2.3.1",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-watch": "^1.0.0",
-    "grunt-env": "^0.4.4",
     "grunt-nodemon": "^0.4.2",
     "grunt-nsp": "^2.3.1",
     "grunt-sass": "^2.0.0",

--- a/test/mock/mockMatchSurnameToAppealService.js
+++ b/test/mock/mockMatchSurnameToAppealService.js
@@ -20,7 +20,7 @@ const matchSurnameToAppeal = (req, res) => {
     req.session[id] = true;
     res.redirect(`/trackyourappeal/${id}`);
   } else {
-    res.status(HttpStatus.BAD_REQUEST);
+    res.status(HttpStatus.NOT_FOUND);
     res.render('validate-surname', {
       id,
       fields: {

--- a/test/unit/core/ErrorHandling.test.js
+++ b/test/unit/core/ErrorHandling.test.js
@@ -49,33 +49,20 @@ describe('ErrorHandling.js', () => {
   });
 
   describe('handleError()', () => {
-    it('should render a 404 error page and log it', () => {
+    it('should render a 404 error page', () => {
       error.status = HttpStatus.NOT_FOUND;
       reformattedError.responseCode = HttpStatus.NOT_FOUND;
       ErrorHandling.handleError(error, req, res, next);
       expect(res.status).to.have.been.calledWith(HttpStatus.NOT_FOUND);
       expect(res.render).to.have.been.calledWith('errors/404.html');
-      expect(logger.error).to.have.been.calledWith(reformattedError);
     });
 
-    it('should render a 500 error page and log it', () => {
+    it('should render a 500 error page', () => {
       error.status = HttpStatus.INTERNAL_SERVER_ERROR;
       reformattedError.responseCode = HttpStatus.INTERNAL_SERVER_ERROR;
       ErrorHandling.handleError(error, req, res, next);
       expect(res.status).to.have.been.calledWith(HttpStatus.INTERNAL_SERVER_ERROR);
       expect(res.render).to.have.been.calledWith('errors/500.html');
-      expect(logger.error).to.have.been.calledWith(reformattedError);
-    });
-  });
-
-  describe('handleErrorDuringDevelopment()', () => {
-    it('should send a json error message', () => {
-      error.status = HttpStatus.NOT_FOUND;
-      reformattedError.responseCode = HttpStatus.NOT_FOUND;
-      ErrorHandling.handleErrorDuringDevelopment(error, req, res, next);
-      expect(res.status).to.have.been.calledWith(HttpStatus.NOT_FOUND);
-      expect(res.send).to.have.been.calledWith(reformattedError);
-      expect(logger.error).to.have.been.calledWith(reformattedError);
     });
   });
 

--- a/test/unit/services/matchSurnameToAppeal.test.js
+++ b/test/unit/services/matchSurnameToAppeal.test.js
@@ -47,9 +47,9 @@ describe('matchSurnameToAppeal.js', () => {
     });
   });
 
-  describe('matchSurnameToAppeal() - HTTP GET /appeals/id/surname/invalidSurname 400', () => {
-    it('should set both res.status() and res.render() when the response is a 400', () => {
-      const error = { statusCode: HttpStatus.NOT_FOUND };
+  describe('matchSurnameToAppeal() - HTTP GET /appeals/id/surname/invalidSurname 404', () => {
+    it('should set both res.status() and res.render() when the response is a 404', () => {
+      const error = { status: HttpStatus.NOT_FOUND };
 
       req.params.id = invalidId;
       req.body.surname = invalidSurname;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2158,13 +2158,6 @@ grunt-contrib-watch@^1.0.0:
     lodash "^3.10.1"
     tiny-lr "^0.2.1"
 
-grunt-env@^0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/grunt-env/-/grunt-env-0.4.4.tgz#3b38843a8d737177ddc9f893879fb69ce1a0bc2f"
-  dependencies:
-    ini "~1.3.0"
-    lodash "~2.4.1"
-
 grunt-known-options@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/grunt-known-options/-/grunt-known-options-1.1.0.tgz#a4274eeb32fa765da5a7a3b1712617ce3b144149"
@@ -3206,10 +3199,6 @@ lodash@^3.10.1, lodash@^3.3.1, lodash@~3.10.1:
 lodash@^4.0.0, lodash@^4.14.0, lodash@^4.14.2, lodash@^4.15.0, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.8.0, lodash@~4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
-
-lodash@~2.4.1:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-2.4.2.tgz#fadd834b9683073da179b3eae6d9c0d15053f73e"
 
 lodash@~4.17.2:
   version "4.17.5"


### PR DESCRIPTION
* Compare the status of an error using 'status' instead of 'statusCode', this fixes the validation issue.
* Removed the NODE_PATH env. var. from the Gruntfile as it's not required
* Removed the 'grunt-env' dependency as it's no longer required.
* Simplified the error handling in preparation of v3 @hmcts/nodejs-logging
