### PR TITLE
Hide the "Check your hearing details" link in historical events

### DIFF
--- a/app/views/track-your-appeal.html
+++ b/app/views/track-your-appeal.html
@@ -96,7 +96,7 @@ Track your Appeal
                         <p>{{ content }}</p>
                         {% endfor %}
 
-                        {% if historicalEvent.contentKey === 'status.hearingBooked' %}
+                        {% if historicalEvent.contentKey === 'status.hearingBooked' and historicalEvent.hearingAddress.lines > 0 %}
                         <a href="/hearingdetails/{{data.appealNumber}}/{{loop.index0}}">{{ i18n.hearingDetails.checkDetails }}</a>
                         {% endif %}
                     </div>


### PR DESCRIPTION
When dealing with past hearing booked events some of the historical events will have no hearing details. If that is the case we need to hide the "Check your hearing details" link to prevent users navigating to an empty hearing details page.


