### PR TITLE
SSCS-3262 validate surname hint text

### DIFF
--- a/app/assets/locale/en.json
+++ b/app/assets/locale/en.json
@@ -312,6 +312,7 @@
     "heading": "Enter your last name - Appeal a benefit decision - GOV.UK",
     "submit": "Track your appeal",
     "surname": {
+      "hint": "This is to check it's your appeal and protect your personal information",
       "errors": {
         "emptyStringHeading": "Enter your last name to continue",
         "notValidHeading": "You have entered an invalid last name. Enter your last name in full",

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -33,9 +33,6 @@ $path: "/public/images/";
   font-style: italic;
 }
 
-.form-hint {
-  color: $black;
-}
 
 .screen-reader-text {
   clip: rect(1px, 1px, 1px, 1px);

--- a/app/views/hearing-details.html
+++ b/app/views/hearing-details.html
@@ -15,7 +15,7 @@ Check your hearing details  {{ i18n.common.titleContext }}
             <h1 class="heading-xlarge">{{ i18n.hearingDetails.checkDetails }}</h1>
             <div class="details">
                 <h2 class="heading-medium">{{ appeal.name }}</h2>
-                <h2 class="form-hint">{{ i18n.common.appealReferenceNumber }}: {{ appeal.caseReference }}</h2>
+                <h2>{{ i18n.common.appealReferenceNumber }}: {{ appeal.caseReference }}</h2>
             </div>
             <div class="divider"></div>
         </div>

--- a/app/views/track-your-appeal.html
+++ b/app/views/track-your-appeal.html
@@ -18,7 +18,7 @@ Track your appeal {{ i18n.common.titleContext }}
 
             <div class="details">
                 <h2 class="heading-medium">{{ data.name }}</h2>
-                <h2 class="form-hint">{{ i18n.common.appealReferenceNumber }}: {{ data.caseReference }}</h2>
+                <h2>{{ i18n.common.appealReferenceNumber }}: {{ data.caseReference }}</h2>
             </div>
 
             <div class="divider"></div>
@@ -89,7 +89,7 @@ Track your appeal {{ i18n.common.titleContext }}
                     <div>
                         <h3 class="bold-small">
                             {{ historicalEvent.heading }}
-                            <span class="form-hint">{{ historicalEvent.date | formatDate }}</span>
+                            <span>{{ historicalEvent.date | formatDate }}</span>
                         </h3>
 
                         {% for content in historicalEvent.renderedContent %}

--- a/app/views/validate-surname.html
+++ b/app/views/validate-surname.html
@@ -21,7 +21,7 @@
 
             {{ textField(
                 label='',
-                hint='',
+                hint=i18n.validateSurname.surname.hint,
                 name='surname',
                 field=fields.surname
             ) }}


### PR DESCRIPTION
- Add hint text to validate surname screen.
- Remove `form-hint` class as it's not needed and removed it from the elements that are using it.