### PR TITLE
change data to fix tests

### DIFF
--- a/test/mock/data/dwpRespond.json
+++ b/test/mock/data/dwpRespond.json
@@ -11,7 +11,7 @@
         "date": "2018-06-08T14:14:20.000Z",
         "type": "DWP_RESPOND",
         "contentKey": "status.dwpRespond",
-        "hearingContactDate": "2018-07-20T14:14:20.000Z"
+        "hearingContactDate": "2018-08-03T14:14:20.000Z"
       }
     ],
     "historicalEvents": [


### PR DESCRIPTION
Change the mock data as there has been a change in the api which calculates the hearingContactDate 8 weeks after the initial date rather than 6 weeks.