### PR TITLE
remove health check from e2e tests

### DIFF
--- a/test/e2e/smoke/health.test.js
+++ b/test/e2e/smoke/health.test.js
@@ -1,8 +1,0 @@
-const paths = require('paths');
-
-Feature('Health');
-
-Scenario('The API is up and responding to requests to /health @smoke', I => {
-  I.amOnPage(paths.health);
-  I.see('"status":"UP"');
-});


### PR DESCRIPTION
As health check already covered as part of build, we can remove this from E2E journey tests