### PR TITLE
SSCS-3509 Explicitly track exceptions in application insights

### DIFF
--- a/app-insights.js
+++ b/app-insights.js
@@ -1,9 +1,17 @@
 const applicationInsights = require('applicationinsights');
 const config = require('config');
 
-const appInsights = () => {
+const enable = () => {
   const iKey = config.get('appInsights.instrumentationKey');
-  applicationInsights.setup(iKey).start();
+  applicationInsights.setup(iKey).setAutoCollectConsole(true, true)
+    .start();
 };
 
-module.exports = appInsights;
+const trackException = exception => {
+  applicationInsights.defaultClient.trackException({ exception });
+};
+
+module.exports = {
+  enable,
+  trackException
+};

--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-require('app-insights')();
+require('app-insights').enable();
 const { Express } = require('@hmcts/nodejs-logging');
 const { tyaNunjucks, filters } = require('app/core/tyaNunjucks');
 const health = require('app/services/health');

--- a/app/services/appealService.js
+++ b/app/services/appealService.js
@@ -1,5 +1,6 @@
 const {get} = require('lodash');
 const apiUrl = require('config').get('api.url');
+const appInsights = require('app-insights');
 const HttpStatus = require('http-status-codes');
 const request = require('superagent');
 const {Logger} = require('@hmcts/nodejs-logging');
@@ -27,6 +28,7 @@ const getAppeal = (req, res, next) => {
         const path = get(error, 'response.body.path');
         error.message = `${message} ${path}`;
       }
+      appInsights.trackException(error);
       next(error);
     });
 };
@@ -48,6 +50,7 @@ const changeEmailAddress = (req, res, next) => {
         logger.info(`POST ${endpoint} ${HttpStatus.OK}`);
         next();
       }).catch((error) => {
+        appInsights.trackException(error);
         next(error);
       });
 };
@@ -67,6 +70,7 @@ const stopReceivingEmails = (req, res, next) => {
       logger.info(`DELETE ${endpoint} ${HttpStatus.OK}`);
       next();
     }).catch((error) => {
+      appInsights.trackException(error);
       next(error);
     });
 

--- a/app/services/matchSurnameToAppeal.js
+++ b/app/services/matchSurnameToAppeal.js
@@ -1,5 +1,6 @@
 const request = require('superagent');
 const api = require('config').get('api.url');
+const appInsights = require('app-insights');
 const HttpStatus = require('http-status-codes');
 const { tya } = require('paths');
 
@@ -32,6 +33,7 @@ const matchSurnameToAppeal = (req, res, next) => {
           }
         });
       } else {
+        appInsights.trackException(error);
         next(error);
       }
     });

--- a/app/services/tokenService.js
+++ b/app/services/tokenService.js
@@ -1,5 +1,6 @@
 const apiUrl = require('config').get('api.url');
 const request = require('superagent');
+const appInsights = require('app-insights');
 const HttpStatus = require('http-status-codes');
 const { Logger } = require('@hmcts/nodejs-logging');
 
@@ -22,6 +23,7 @@ const validateToken = (req, res, next) => {
         // Provide a better error message.
         error.message = error.rawResponse;
       }
+      appInsights.trackException(error);
       next(error);
     });
 };

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@hmcts/nodejs-healthcheck": "^1.4.5",
     "@hmcts/nodejs-logging": "^3.0.0",
-    "applicationinsights": "1.0.1",
+    "applicationinsights": "^1.0.1",
     "body-parser": "^1.17.1",
     "config": "^1.30.0",
     "cookie-parser": "^1.4.3",

--- a/test/unit/services/matchSurnameToAppeal.test.js
+++ b/test/unit/services/matchSurnameToAppeal.test.js
@@ -2,6 +2,7 @@ const { matchSurnameToAppeal } = require('app/services/matchSurnameToAppeal');
 const { expect, sinon } = require('test/chai-sinon');
 const nock = require('nock');
 const apiURL = require('config').get('api.url');
+const appInsights = require('app-insights');
 const HttpStatus = require('http-status-codes');
 const validateSurname = require('app/assets/locale/en').validateSurname;
 
@@ -79,17 +80,26 @@ describe('matchSurnameToAppeal.js', () => {
           expect(req.session).to.not.have.property(req.params.id);
         });
     });
+  });
 
+  describe('matchSurnameToAppeal() - HTTP GET 500', () => {
+    beforeEach(() => {
+      sinon.spy(appInsights, 'trackException');
+    });
+    afterEach(() => {
+      appInsights.trackException.restore();
+    });
     it('should call next() passing an error containing a 500', () => {
       const error = { value: HttpStatus.INTERNAL_SERVER_ERROR, reason: 'server error' };
 
       nock(apiURL)
-        .get(`/appeals/${invalidId}/surname/${invalidSurname}`)
+        .get(`/appeals/${req.params.id}/surname/${req.body.surname}`)
         .replyWithError(error);
 
       return matchSurnameToAppeal(req, res, next)
-        .catch(() => {
+        .then(() => {
           expect(next).to.have.been.calledWith(error);
+          expect(appInsights.trackException).to.have.been.calledOnce.calledWith(error);
           expect(req.session).to.not.have.property(req.params.id);
         });
     });


### PR DESCRIPTION
* adding `trackException` calls for issues connecting to the API
* fixing existing tests that were giving false positives due to using `.catch()` instead of `.then()`
* adding tests for the call to app insights