### PR TITLE
Remove no-cache policy

### DIFF
--- a/app.js
+++ b/app.js
@@ -67,7 +67,7 @@ app.use((req, res, next) => {
   // Setting headers stops pages being indexed even if indexed pages link to them.
   res.setHeader('X-Robots-Tag', 'noindex');
   res.setHeader('X-Served-By', os.hostname());
-  res.setHeader('Cache-Control', 'no-cache, max-age=0, must-revalidate, no-store');
+  res.setHeader('Cache-Control', 'max-age=7200');
   next();
 });
 


### PR DESCRIPTION
Related to SSCS-4181


This stategy doens't seem to be needed or desireable, it causes all the
assets to be downloade on every page load, which is detrimental to
performance and server scalability.

It was put in place alledgedly for security reasons on the following
commit, but no records of the rationale could be found.

https://github.com/hmcts/sscs-track-your-appeal-frontend/commit/b6cebf7f2d94e705be24178f7a2b445c0545f6f5

During the investigation it was posited that the reason could have been the
strategy described in this document (TL;DR: don't cache assets because
you may end up with bugs in stale code after you fix them) but there are
better ways to deal with that.

https://helmetjs.github.io/docs/nocache/

While it's probably safe to remove the policy entirely and let Browsers implement
their own heuristic, this change errs on the side of caution and limits caching to
2h, which should be enough time to complete a user journey and at
the same short enough that stale code would be very
difficult to exploit.

