### PR TITLE
Add infra for shared app insights

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -44,6 +44,8 @@ module "tya-frontend" {
   asp_rg               = "${local.app_service_plan}"
   asp_name             = "${local.app_service_plan}"
 
+  appinsights_instrumentation_key = "${var.appinsights_instrumentation_key}"
+
   app_settings = {
     SSCS_API_URL                 = "${local.ApiUrl}"
     WEBSITE_NODE_DEFAULT_VERSION = "8.9.4"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -33,6 +33,12 @@ variable "additional_hostname" {
 variable "common_tags" {
   type = "map"
 }
+
 variable "raw_product" {
   default = "sscs" // jenkins-library overrides product for PRs and adds e.g. pr-118-cmc
+}
+
+variable "appinsights_instrumentation_key" {
+  description = "Instrumentation key of the App Insights instance this webapp should use. Module will create own App Insights resource if this is not provided"
+  default     = ""
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/SSCS-3938

This adds the Terraform changes required for TYA front end to use the shared appinsights resource.

The pipeline will delete the old logs before switching to the shared app insights resource. In order to retain the previous log resource, we will require the following from someone with access to make production changes in Azure. 

These changes must be applied before this PR is merged.

1) Move the previous app insights instance to a new resource group:

sscs-tya-frontend-appinsights-prod into resource group sscs-logretention-prod

This might be enough, but in testing with AAT we have added an extra step:

2) Rename the app insights resource:

sscs-tya-frontend-appinsights-prod to sscs-tya-frontend-logretention-appinsights-prod
